### PR TITLE
Cope with files which are not whole numbers of clusters

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -101,7 +101,7 @@ let decode filename output =
         >>= function
         | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
         | `Ok y ->
-          Mirage_block.copy (module B) x (module Block) y
+          Mirage_block.sparse_copy (module B) x (module Block) y
           >>= function
           | `Error _ -> failwith "copy failed"
           | `Ok () -> return (`Ok ()) in

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -76,7 +76,7 @@ let repair filename =
           return (`Ok ()) in
   Lwt_main.run t
 
-let copy filename output =
+let decode filename output =
   let module B = Qcow.Make(Block) in
   let open Lwt in
   let t =

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -79,6 +79,15 @@ let decode_cmd =
   Term.(ret(pure Impl.decode $ filename $ output)),
   Term.info "decode" ~sdocs:_common_options ~doc ~man
 
+let encode_cmd =
+  let doc = "Convert the file from raw to qcow2" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Convert a raw file to qcow2 ."
+  ] @ help in
+  Term.(ret(pure Impl.encode $ filename $ output)),
+  Term.info "encode" ~sdocs:_common_options ~doc ~man
+
 let create_cmd =
   let doc = "create a qcow-formatted data file" in
   let man = [
@@ -105,7 +114,7 @@ let default_cmd =
   Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t)),
   Term.info "qcow-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
 
-let cmds = [info_cmd; copy_cmd; create_cmd; check_cmd; repair_cmd]
+let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd]
 
 let _ =
   match Term.eval_choice default_cmd cmds with

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -70,14 +70,14 @@ let check_cmd =
   Term.(ret(pure Impl.check $ filename)),
   Term.info "check" ~sdocs:_common_options ~doc ~man
 
-let copy_cmd =
-  let doc = "decode qcow2 formatted data and write to stdout" in
+let decode_cmd =
+  let doc = "decode qcow2 formatted data and write a raw image" in
   let man = [
     `S "DESCRIPTION";
-    `P "Decode qcow2 formatted data and write to stdout.";
+    `P "Decode qcow2 formatted data and write to a raw file.";
   ] @ help in
-  Term.(ret(pure Impl.copy $ filename $ output)),
-  Term.info "copy" ~sdocs:_common_options ~doc ~man
+  Term.(ret(pure Impl.decode $ filename $ output)),
+  Term.info "decode" ~sdocs:_common_options ~doc ~man
 
 let create_cmd =
   let doc = "create a qcow-formatted data file" in

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -22,7 +22,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
 
   val create: B.t -> int64 -> [ `Ok of t | `Error of error ] io
   (** [create block size] initialises a qcow-formatted image on [block]
-      with virtual size [size]. *)
+      with virtual size [size] in bytes. *)
 
   val connect: B.t -> [ `Ok of t | `Error of error ] io
   (** [connect block] connects to an existing qcow-formatted image on


### PR DESCRIPTION
`qemu-img` seems to "allocate" the final cluster in a file by writing
a single sector only. Cope with this by:

- on every `read`, check if we're in this last-cluster situation and
  synthesize zeroes for missing sectors
- on `connect`, round up to the next cluster size when setting the
  `next_cluster` pointer.

With this patch, a `qemu-img` generated .qcow2 seems to work ok with
this code as measured by the CLI `check` subcommand.

Signed-off-by: David Scott <dave.scott@unikernel.com>