### PR TITLE
Fix infinite loop enlarging the refcount table

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -108,13 +108,31 @@ let repair_cmd =
   Term.(ret(pure Impl.repair $ filename)),
   Term.info "repair" ~sdocs:_common_options ~doc ~man
 
+let sector =
+  let doc = Printf.sprintf "Virtual sector within the qcow2 image" in
+  Arg.(value & opt int64 0L & info [ "sector" ] ~doc)
+
+let text =
+  let doc = Printf.sprintf "Test to write into the qcow2 image" in
+  Arg.(value & opt string "" & info [ "text" ] ~doc)
+
+let write_cmd =
+  let doc = "Write a string to a virtual address in a qcow2 image" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Write a string at a given virtual sector offset in the qcow2 image."
+  ] @ help in
+  Term.(ret(pure Impl.write $ filename $ sector $ text)),
+  Term.info "write" ~sdocs:_common_options ~doc ~man
+
 let default_cmd =
   let doc = "manipulate virtual disks stored in qcow2 files" in
   let man = help in
   Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t)),
   Term.info "qcow-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
 
-let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd]
+let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
+  write_cmd]
 
 let _ =
   match Term.eval_choice default_cmd cmds with

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -125,6 +125,19 @@ let write_cmd =
   Term.(ret(pure Impl.write $ filename $ sector $ text)),
   Term.info "write" ~sdocs:_common_options ~doc ~man
 
+let length =
+  let doc = Printf.sprintf "Length of the data in 512-byte sectors" in
+  Arg.(value & opt int64 1L & info [ "length" ] ~doc)
+
+let read_cmd =
+  let doc = "Read a string from a virtual address in a qcow2 image" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Read a string at a given virtual sector offset in the qcow2 image."
+  ] @ help in
+  Term.(ret(pure Impl.read $ filename $ sector $ length)),
+  Term.info "read" ~sdocs:_common_options ~doc ~man
+
 let default_cmd =
   let doc = "manipulate virtual disks stored in qcow2 files" in
   let man = help in
@@ -132,7 +145,7 @@ let default_cmd =
   Term.info "qcow-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
 
 let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
-  write_cmd]
+  write_cmd; read_cmd]
 
 let _ =
   match Term.eval_choice default_cmd cmds with

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -46,6 +46,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
   (** [rebuild_refcount_table t] rebuilds the refcount table from scratch.
       Normally we won't update the refcount table live, for performance. *)
 
+  val header: t -> Header.t
+  (** Return a snapshot of the current header *)
+
   module Debug: Qcow_s.DEBUG
     with type t = t
      and type error = error

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -68,4 +68,6 @@ module type DEBUG = sig
   type error
 
   val check_no_overlaps: t -> [ `Ok of unit | `Error of error ] Lwt.t
+
+  val set_next_cluster: t -> int64 -> unit
 end

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -272,6 +272,30 @@ let read_write sector_size size_sectors (start, length) () =
     Lwt.return () in
   Lwt_main.run t
 
+let check_refcount_table_allocation () =
+  let module B = Qcow.Make(Ramdisk) in
+  let t =
+    Ramdisk.destroy ~name:"test";
+    Ramdisk.connect "test"
+    >>= fun x ->
+    let ramdisk = expect_ok x in
+    B.create ramdisk pib
+    >>= fun x ->
+    let b = expect_ok x in
+
+    let h = B.header b in
+    let max_cluster = Int64.shift_right h.Header.size (Int32.to_int h.Header.cluster_bits) in
+    B.Debug.set_next_cluster b (Int64.pred max_cluster);
+    let length = 1 lsl (Int32.to_int h.Header.cluster_bits) in
+    let sector = 0L in
+
+    let buf = malloc length in
+    B.write b sector (fragment 4096 buf)
+    >>= fun x ->
+    let () = expect_ok x in
+    Lwt.return () in
+  Lwt_main.run t
+
 let _ =
   let sector_size = 512 in
   (* Test with a 1 PiB disk, bigger than we'll need for a while. *)
@@ -282,6 +306,7 @@ let _ =
     (interesting_ranges sector_size size_sectors cluster_bits) in
 
   let suite = "qcow2" >::: [
+    "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
     "create 1K" >:: create_1K;
     "create 1M" >:: create_1M;
     "create 1P" >:: create_1P;


### PR DESCRIPTION

- Fix an infinite loop when enlarging the refcount table
- add CLI commands `read` and `write`