### PR TITLE
Reindent with ocp-indent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean install build
+.PHONY: all clean install build reindent
 all: build test doc
 
 PREFIX ?= /usr/local
@@ -43,6 +43,11 @@ reinstall: setup.bin
 uninstall:
 	ocamlfind remove $(NAME) || true
 	rm -f ${BINDIR}/qcow-tool || true
+
+reindent:
+	ocp-indent --syntax cstruct -i lib/*.mli
+	ocp-indent --syntax cstruct -i lib/*.ml
+	ocp-indent --syntax cstruct -i lib_test/*.ml
 
 clean:
 	ocamlbuild -clean

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -70,11 +70,11 @@ end
 type offset = int64 with sexp
 
 type extension = {
- incompatible_features: int64;
- compatible_features: int64;
- autoclear_features: int64;
- refcount_order: int32;
- header_length: int32;
+  incompatible_features: int64;
+  compatible_features: int64;
+  autoclear_features: int64;
+  refcount_order: int32;
+  header_length: int32;
 } with sexp
 
 type t = {
@@ -185,8 +185,8 @@ let read rest =
   Int64.read rest
   >>= fun (snapshots_offset, rest) ->
   return ({ version; backing_file_offset; backing_file_size; cluster_bits;
-    size; crypt_method; l1_size; l1_table_offset; refcount_table_offset;
-    refcount_table_clusters; nb_snapshots; snapshots_offset }, rest)
+            size; crypt_method; l1_size; l1_table_offset; refcount_table_offset;
+            refcount_table_clusters; nb_snapshots; snapshots_offset }, rest)
 
 
 let refcounts_per_cluster t =

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -35,11 +35,11 @@ type offset = int64
 (** Offset within the image *)
 
 type extension = {
- incompatible_features: int64;
- compatible_features: int64;
- autoclear_features: int64;
- refcount_order: int32;
- header_length: int32;
+  incompatible_features: int64;
+  compatible_features: int64;
+  autoclear_features: int64;
+  refcount_order: int32;
+  header_length: int32;
 } with sexp
 
 type t = {

--- a/lib/qcow_physical.ml
+++ b/lib/qcow_physical.ml
@@ -25,9 +25,9 @@ let ( |> ) = Int64.shift_right_logical
    remembering the byte value and force implementations to round on demand *)
 
 type t = {
-	bytes: int64;
-	is_mutable: bool;
-	is_compressed: bool;
+  bytes: int64;
+  is_mutable: bool;
+  is_compressed: bool;
 }
 with sexp
 
@@ -38,8 +38,8 @@ let sizeof _ = 8
 let shift t bytes = { t with bytes = Int64.add t.bytes bytes }
 
 let make ?(is_mutable = true) ?(is_compressed = false) x =
-	let bytes = (x <| 2) |> 2 in
-	{ bytes; is_mutable; is_compressed}
+  let bytes = (x <| 2) |> 2 in
+  { bytes; is_mutable; is_compressed}
 
 let is_mutable t = t.is_mutable
 let is_compressed t = t.is_compressed
@@ -61,11 +61,11 @@ let read rest =
   let is_mutable = x |> 63 = 1L in
   let is_compressed = (x <| 1) |> 63 = 1L in
   let bytes = (x <| 2) |> 2 in
-	Ok({bytes; is_mutable; is_compressed}, Cstruct.shift rest 8)
+  Ok({bytes; is_mutable; is_compressed}, Cstruct.shift rest 8)
 
 let write t rest =
   let is_mutable = if t.is_mutable then 1L <| 63 else 0L in
-	let is_compressed = if t.is_compressed then 1L <| 62 else 0L in
-	let raw = Int64.(logor (logor t.bytes is_mutable) is_compressed) in
-	Cstruct.BE.set_uint64 rest 0 raw;
-	Ok(Cstruct.shift rest 8)
+  let is_compressed = if t.is_compressed then 1L <| 62 else 0L in
+  let raw = Int64.(logor (logor t.bytes is_mutable) is_compressed) in
+  Cstruct.BE.set_uint64 rest 0 raw;
+  Ok(Cstruct.shift rest 8)

--- a/lib/qcow_physical.mli
+++ b/lib/qcow_physical.mli
@@ -16,8 +16,8 @@
  *)
 
 (* TODO:
-  - represent 0L as a None
-	*)
+   - represent 0L as a None
+   	*)
 
 type t with sexp
 (** A physical address within the backing disk *)
@@ -35,7 +35,7 @@ val shift: t -> int64 -> t
 val make: ?is_mutable:bool -> ?is_compressed:bool -> int64 -> t
 (** Create an address at the given byte offset. This defaults to [is_mutable = true]
     which meand there are no snapshots implying that directly writing to this
-		offset is ok; and [is_compressed = false]. *)
+    		offset is ok; and [is_compressed = false]. *)
 
 val to_sector: sector_size:int -> t -> int64 * int
 (** Return the sector on disk, plus a remainder within the sector *)

--- a/lib/qcow_types.mli
+++ b/lib/qcow_types.mli
@@ -49,7 +49,7 @@ module Int64 : sig
 
   val t_of_sexp: Sexp.t -> t
   val sexp_of_t: t -> Sexp.t
-  
+
   val round_up: int64 -> int64 -> int64
   (** [round_up value to] rounds [value] to the next multiple of [to] *)
 

--- a/lib/qcow_virtual.ml
+++ b/lib/qcow_virtual.ml
@@ -18,25 +18,25 @@ open Sexplib.Std
 
 (* An address in a qcow image is broken into 3 levels: *)
 type t = {
-	l1_index: int64; (* index in the L1 table *)
-	l2_index: int64; (* index in the L2 table *)
-	cluster: int64;  (* index within the cluster *)
+  l1_index: int64; (* index in the L1 table *)
+  l2_index: int64; (* index in the L2 table *)
+  cluster: int64;  (* index within the cluster *)
 } with sexp
 
 let ( <| ) = Int64.shift_left
 let ( |> ) = Int64.shift_right_logical
 
 let make ~cluster_bits x =
-	let l2_bits = cluster_bits - 3 in
-	let l1_index = x |> (l2_bits + cluster_bits) in
-	let l2_index = (x <| (64 - l2_bits - cluster_bits)) |> (64 - l2_bits) in
-	let cluster  = (x <| (64 - cluster_bits)) |> (64 - cluster_bits) in
-	{ l1_index; l2_index; cluster }
+  let l2_bits = cluster_bits - 3 in
+  let l1_index = x |> (l2_bits + cluster_bits) in
+  let l2_index = (x <| (64 - l2_bits - cluster_bits)) |> (64 - l2_bits) in
+  let cluster  = (x <| (64 - cluster_bits)) |> (64 - cluster_bits) in
+  { l1_index; l2_index; cluster }
 
 let to_offset ~cluster_bits t =
   let l2_bits = cluster_bits - 3 in
   let l1_index = t.l1_index <| (l2_bits + cluster_bits) in
-	let l2_index = t.l2_index <| cluster_bits in
-	Int64.(logor (logor l1_index l2_index) t.cluster)
+  let l2_index = t.l2_index <| cluster_bits in
+  Int64.(logor (logor l1_index l2_index) t.cluster)
 
 let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)

--- a/lib/qcow_virtual.mli
+++ b/lib/qcow_virtual.mli
@@ -15,15 +15,15 @@
  *
  *)
 
- type t = {
- 	l1_index: int64; (* index in the L1 table *)
- 	l2_index: int64; (* index in the L2 table *)
- 	cluster: int64;  (* index within the cluster *)
- } with sexp
- (** A virtual address in a qcow image is broken into 3 levels:
-     - an index in the L1 table, pointing to
-		 - an index in the L2 table, pointing to
-		 - a cluster within which we need an offset *)
+type t = {
+  l1_index: int64; (* index in the L1 table *)
+  l2_index: int64; (* index in the L2 table *)
+  cluster: int64;  (* index within the cluster *)
+} with sexp
+(** A virtual address in a qcow image is broken into 3 levels:
+    - an index in the L1 table, pointing to
+    		 - an index in the L2 table, pointing to
+    		 - a cluster within which we need an offset *)
 
 val make: cluster_bits:int -> int64 -> t
 (** [make cluster_bits byte] computes the address within the file

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -98,11 +98,11 @@ let boundaries cluster_bits =
     Printf.sprintf "one %Ld byte cluster" cluster_size, cluster_size;
     Printf.sprintf "one L2 table (containing %Ld 8-byte pointers to cluster)"
       pointers_in_cluster,
-      Int64.(mul cluster_size pointers_in_cluster);
+    Int64.(mul cluster_size pointers_in_cluster);
     Printf.sprintf "one L1 table (containing %Ld 8-byte pointers to L2 tables)"
       pointers_in_cluster,
-      Int64.(mul (mul cluster_size pointers_in_cluster) pointers_in_cluster)
-    ]
+    Int64.(mul (mul cluster_size pointers_in_cluster) pointers_in_cluster)
+  ]
 
 let sizes sector_size cluster_bits = [
   "one sector", Int64.of_int sector_size;
@@ -128,11 +128,11 @@ let interesting_ranges sector_size size_sectors cluster_bits =
   let all = starts @ (List.map (fun (label, offset) -> label ^ " from the end", Int64.sub size_bytes offset) starts) in
   (* add lengths *)
   let all = List.map (fun ((label', length'), (label, offset)) ->
-    label' ^ " @ " ^ label, offset, length'
-  ) (cross (sizes sector_size cluster_bits) all) in
+      label' ^ " @ " ^ label, offset, length'
+    ) (cross (sizes sector_size cluster_bits) all) in
   List.filter
     (fun (label, offset, length) ->
-      offset >= 0L && (Int64.add offset length <= size_bytes)
+       offset >= 0L && (Int64.add offset length <= size_bytes)
     ) all
 
 let get_id =
@@ -242,25 +242,25 @@ let read_write sector_size size_sectors (start, length) () =
     let ofs' = Int64.(mul sector (of_int sector_size)) in
     Mirage_block.fold_mapped_s
       ~f:(fun bytes_seen ofs data ->
-        let actual = { Extent.start = ofs; length = Int64.of_int (Cstruct.len data / 512) } in
-        (* Any data we read now which wasn't expected must be full of zeroes *)
-        let extra = Extent.difference actual expected in
-        List.iter
-          (fun { Extent.start; length } ->
-            let buf = Cstruct.sub data (512 * Int64.(to_int (sub start ofs))) (Int64.to_int length * 512) in
-            for i = 0 to Cstruct.len buf - 1 do
-              assert_equal ~printer:string_of_int ~cmp:(fun a b -> a = b) 0 (Cstruct.get_uint8 buf i)
-            done;
-          ) extra;
-        let common = Extent.intersect actual expected in
-        List.iter
-          (fun { Extent.start; length } ->
-            let buf = Cstruct.sub data (512 * Int64.(to_int (sub start ofs))) (Int64.to_int length * 512) in
-            for i = 0 to Cstruct.len buf - 1 do
-              assert_equal ~printer:string_of_int ~cmp:(fun a b -> a = b) (id mod 256) (Cstruct.get_uint8 buf i)
-            done;
-          ) common;
-        let seen_this_time = 512 * List.(fold_left (+) 0 (map (fun e -> Int64.to_int e.Extent.length) common)) in
+          let actual = { Extent.start = ofs; length = Int64.of_int (Cstruct.len data / 512) } in
+          (* Any data we read now which wasn't expected must be full of zeroes *)
+          let extra = Extent.difference actual expected in
+          List.iter
+            (fun { Extent.start; length } ->
+               let buf = Cstruct.sub data (512 * Int64.(to_int (sub start ofs))) (Int64.to_int length * 512) in
+               for i = 0 to Cstruct.len buf - 1 do
+                 assert_equal ~printer:string_of_int ~cmp:(fun a b -> a = b) 0 (Cstruct.get_uint8 buf i)
+               done;
+            ) extra;
+          let common = Extent.intersect actual expected in
+          List.iter
+            (fun { Extent.start; length } ->
+               let buf = Cstruct.sub data (512 * Int64.(to_int (sub start ofs))) (Int64.to_int length * 512) in
+               for i = 0 to Cstruct.len buf - 1 do
+                 assert_equal ~printer:string_of_int ~cmp:(fun a b -> a = b) (id mod 256) (Cstruct.get_uint8 buf i)
+               done;
+            ) common;
+          let seen_this_time = 512 * List.(fold_left (+) 0 (map (fun e -> Int64.to_int e.Extent.length) common)) in
           return (`Ok (bytes_seen + seen_this_time))
         ) 0 (module B) b
     >>= fun x ->
@@ -334,14 +334,14 @@ let _ =
   let size_sectors = Int64.div pib 512L in
   let cluster_bits = 16 in
   let interesting_writes = List.map
-    (fun (label, start, length) -> label >:: read_write sector_size size_sectors (start, Int64.to_int length))
-    (interesting_ranges sector_size size_sectors cluster_bits) in
+      (fun (label, start, length) -> label >:: read_write sector_size size_sectors (start, Int64.to_int length))
+      (interesting_ranges sector_size size_sectors cluster_bits) in
 
   let suite = "qcow2" >::: [
-    "check we can fill the disk" >:: check_full_disk;
-    "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
-    "create 1K" >:: create_1K;
-    "create 1M" >:: create_1M;
-    "create 1P" >:: create_1P;
-  ] @ interesting_writes in
+      "check we can fill the disk" >:: check_full_disk;
+      "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
+      "create 1K" >:: create_1K;
+      "create 1M" >:: create_1M;
+      "create 1P" >:: create_1P;
+    ] @ interesting_writes in
   OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)


### PR DESCRIPTION
This patch also adds a target `make reindent`

Signed-off-by: David Scott <dave.scott@unikernel.com>