### PR TITLE
Add simple wrappers around qemu commands for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
   global:
     - PACKAGE="qcow-format" OCAML_VERSION=4.02
     - COV_CONF="export TESTS=--enable-tests"
-    - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils"
+    - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PACKAGE="qcow-format" OCAML_VERSION=4.02 PINS="nbd:git://github.com/xapi-project/nbd"
+    - PACKAGE="qcow-format" OCAML_VERSION=4.02
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ script: bash -ex .travis-opam.sh && bash -ex travis-coveralls.sh
 sudo: required
 env:
   global:
-    - PACKAGE="qcow" OCAML_VERSION=4.02 PINS="mirage-block-ramdisk:git://github.com/mirage/mirage-block-ramdisk mirage-block:git://github.com/mirage/mirage-block mirage-block-unix:git://github.com/mirage/mirage-block-unix"
+    - PACKAGE="qcow-format" OCAML_VERSION=4.02 PINS="mirage-block-ramdisk:git://github.com/mirage/mirage-block-ramdisk mirage-block:git://github.com/mirage/mirage-block mirage-block-unix:git://github.com/mirage/mirage-block-unix"
     - COV_CONF="export TESTS=--enable-tests"
-    - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils; opam install oasis -y"
+    - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: c
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
   - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
-script: bash -ex .travis-opam.sh && bash -ex travis-coveralls.sh
+script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PACKAGE="qcow-format" OCAML_VERSION=4.02 PINS="mirage-block-ramdisk:git://github.com/mirage/mirage-block-ramdisk mirage-block:git://github.com/mirage/mirage-block mirage-block-unix:git://github.com/mirage/mirage-block-unix"
+    - PACKAGE="qcow-format" OCAML_VERSION=4.02 PINS="nbd:git://github.com/xapi-project/nbd"
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install:
   - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
 script: bash -ex .travis-opam.sh
 sudo: required
+dist: trusty
 env:
   global:
     - PACKAGE="qcow-format" OCAML_VERSION=4.02

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ env:
   global:
     - PACKAGE="qcow" OCAML_VERSION=4.02 PINS="mirage-block-ramdisk:git://github.com/mirage/mirage-block-ramdisk mirage-block:git://github.com/mirage/mirage-block mirage-block-unix:git://github.com/mirage/mirage-block-unix"
     - COV_CONF="export TESTS=--enable-tests"
+    - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils; opam install oasis -y"

--- a/_oasis
+++ b/_oasis
@@ -38,7 +38,7 @@ Executable test
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page
+  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm
 
 Test test
   Run$:               flag(tests)

--- a/_oasis
+++ b/_oasis
@@ -38,7 +38,7 @@ Executable test
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm
+  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm, nbd, nbd.lwt
 
 Test test
   Run$:               flag(tests)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -704,14 +704,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     let l2_tables_required = Header.l2_tables_required ~cluster_bits size in
     let nb_snapshots = 0l in
     let snapshots_offset = 0L in
-    let extension = None in
+    let additional = None in
     let h = {
       Header.version; backing_file_offset; backing_file_size;
       cluster_bits = Int32.of_int cluster_bits; size; crypt_method;
       l1_size = Int64.to_int32 l2_tables_required;
       l1_table_offset; refcount_table_offset;
       refcount_table_clusters = Int64.to_int32 refcount_table_clusters;
-      nb_snapshots; snapshots_offset; extension
+      nb_snapshots; snapshots_offset; additional;
     } in
     (* Resize the underlying device to contain the header + refcount table
        + l1 table. Future allocations will enlarge the file. *)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -688,7 +688,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     else update_header t { t.h with Header.l1_size = Int64.to_int32 l2_tables_required }
 
   let create base size =
-    let version = `Two in
+    let version = `Three in
     let backing_file_offset = 0L in
     let backing_file_size = 0l in
     let cluster_bits = 16 in
@@ -704,7 +704,13 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     let l2_tables_required = Header.l2_tables_required ~cluster_bits size in
     let nb_snapshots = 0l in
     let snapshots_offset = 0L in
-    let additional = None in
+    let additional = Some {
+      Header.dirty = true;
+      corrupt = false;
+      lazy_refcounts = true;
+      autoclear_features = 0L;
+      refcount_order = 4l;
+      } in
     let extensions = [] in
     let h = {
       Header.version; backing_file_offset; backing_file_size;

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -704,13 +704,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     let l2_tables_required = Header.l2_tables_required ~cluster_bits size in
     let nb_snapshots = 0l in
     let snapshots_offset = 0L in
+    let extension = None in
     let h = {
       Header.version; backing_file_offset; backing_file_size;
       cluster_bits = Int32.of_int cluster_bits; size; crypt_method;
       l1_size = Int64.to_int32 l2_tables_required;
       l1_table_offset; refcount_table_offset;
       refcount_table_clusters = Int64.to_int32 refcount_table_clusters;
-      nb_snapshots; snapshots_offset
+      nb_snapshots; snapshots_offset; extension
     } in
     (* Resize the underlying device to contain the header + refcount table
        + l1 table. Future allocations will enlarge the file. *)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -338,7 +338,10 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
         ( if Physical.to_bytes addr = 0L then begin
               allocate_clusters t 1L
               >>*= fun cluster ->
-              let addr = Physical.make (cluster <| t.cluster_bits) in
+              (* NB: the pointers in the refcount table are different from the pointers
+                 in the cluster table: the high order bits are not used to encode extra
+                 information and wil confuse qemu/qemu-img. *)
+              let addr = Physical.make ~is_mutable:false (cluster <| t.cluster_bits) in
               (* zero the cluster *)
               let buf = malloc t.h in
               Cstruct.memset buf 0;

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -705,13 +705,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     let nb_snapshots = 0l in
     let snapshots_offset = 0L in
     let additional = None in
+    let extensions = [] in
     let h = {
       Header.version; backing_file_offset; backing_file_size;
       cluster_bits = Int32.of_int cluster_bits; size; crypt_method;
       l1_size = Int64.to_int32 l2_tables_required;
       l1_table_offset; refcount_table_offset;
       refcount_table_clusters = Int64.to_int32 refcount_table_clusters;
-      nb_snapshots; snapshots_offset; additional;
+      nb_snapshots; snapshots_offset; additional; extensions;
     } in
     (* Resize the underlying device to contain the header + refcount table
        + l1 table. Future allocations will enlarge the file. *)

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -81,7 +81,6 @@ type additional = {
   lazy_refcounts: bool;
   autoclear_features: int64;
   refcount_order: int32;
-  header_length: int32;
 } with sexp
 
 type t = {
@@ -175,7 +174,8 @@ let write t rest =
     >>= fun rest ->
     Int32.write e.refcount_order rest
     >>= fun rest ->
-    Int32.write e.header_length rest
+    let header_length = Int32.of_int (sizeof t) in
+    Int32.write header_length rest
 
 let read rest =
   Int8.read rest
@@ -275,7 +275,7 @@ let read rest =
       >>= fun (e, rest) ->
       let extensions = List.map parse_extension e in
       return (Some { dirty; corrupt; lazy_refcounts; autoclear_features;
-                refcount_order; header_length }, extensions, rest)
+                refcount_order }, extensions, rest)
   ) >>= fun (additional, extensions, rest) ->
   return ({ version; backing_file_offset; backing_file_size; cluster_bits;
             size; crypt_method; l1_size; l1_table_offset; refcount_table_offset;

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -69,7 +69,7 @@ end
 
 type offset = int64 with sexp
 
-type extension = {
+type additional = {
   dirty: bool;
   corrupt: bool;
   lazy_refcounts: bool;
@@ -91,7 +91,7 @@ type t = {
   refcount_table_clusters: int32;
   nb_snapshots: int32;
   snapshots_offset: offset;
-  extension: extension option;
+  additional: additional option;
 } with sexp
 
 let compare (a: t) (b: t) = compare a b
@@ -135,7 +135,7 @@ let write t rest =
   >>= fun rest ->
   Int64.write t.snapshots_offset rest
   >>= fun rest ->
-  match t.extension with
+  match t.additional with
   | None -> return rest
   | Some e ->
     let incompatible_features =
@@ -238,10 +238,10 @@ let read rest =
       >>= fun (header_length, rest) ->
       return (Some { dirty; corrupt; lazy_refcounts; autoclear_features;
                 refcount_order; header_length }, rest)
-  ) >>= fun (extension, rest) ->
+  ) >>= fun (additional, rest) ->
   return ({ version; backing_file_offset; backing_file_size; cluster_bits;
             size; crypt_method; l1_size; l1_table_offset; refcount_table_offset;
-            refcount_table_clusters; nb_snapshots; snapshots_offset; extension }, rest)
+            refcount_table_clusters; nb_snapshots; snapshots_offset; additional }, rest)
 
 
 let refcounts_per_cluster t =

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -282,7 +282,8 @@ let read rest =
             size; crypt_method; l1_size; l1_table_offset; refcount_table_offset;
             refcount_table_clusters; nb_snapshots; snapshots_offset; additional;
             extensions } in
-  if sizeof t <> header_length
+  (* qemu excludes extensions from the header_length *)
+  if sizeof { t with extensions = [] } <> header_length
   then error_msg "Read a header_length of %d but we computed %d" header_length (sizeof t)
   else return (t, rest)
 

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -228,6 +228,10 @@ let read rest =
       let lazy_refcounts = Int64.logand 1L (compatible_features |> 0) = 1L in
       Int64.read rest
       >>= fun (autoclear_features, rest) ->
+      ( if autoclear_features <> 0L
+        then error_msg "dealing with autoclear_features not implemented"
+        else return ()
+      ) >>= fun () ->
       Int32.read rest
       >>= fun (refcount_order, rest) ->
       Int32.read rest

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -34,7 +34,7 @@ end
 type offset = int64
 (** Offset within the image *)
 
-type extension = {
+type additional = {
   dirty: bool;
   corrupt: bool;
   lazy_refcounts: bool;
@@ -56,7 +56,7 @@ type t = {
   refcount_table_clusters: int32; (** size of the refcount table in clusters *)
   nb_snapshots: int32;            (** the number of internal snapshots *)
   snapshots_offset: offset;       (** offset of the snapshot header *)
-  extension: extension option;    (** for version 3 or higher *)
+  additional: additional option;    (** for version 3 or higher *)
 } with sexp
 (** The qcow2 header *)
 

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -55,6 +55,7 @@ type t = {
   refcount_table_clusters: int32; (** size of the refcount table in clusters *)
   nb_snapshots: int32;            (** the number of internal snapshots *)
   snapshots_offset: offset;       (** offset of the snapshot header *)
+  extension: extension option;    (** for version 3 or higher *)
 } with sexp
 (** The qcow2 header *)
 

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -46,7 +46,6 @@ type additional = {
   lazy_refcounts: bool;
   autoclear_features: int64;
   refcount_order: int32;
-  header_length: int32;
 } with sexp
 (** Version 3 and above have additional header fields *)
 

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -37,7 +37,7 @@ type offset = int64
 type extension = {
   dirty: bool;
   corrupt: bool;
-  compatible_features: int64;
+  lazy_refcounts: bool;
   autoclear_features: int64;
   refcount_order: int32;
   header_length: int32;

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -35,7 +35,8 @@ type offset = int64
 (** Offset within the image *)
 
 type extension = {
-  incompatible_features: int64;
+  dirty: bool;
+  corrupt: bool;
   compatible_features: int64;
   autoclear_features: int64;
   refcount_order: int32;

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -34,6 +34,12 @@ end
 type offset = int64
 (** Offset within the image *)
 
+type extension = [
+  | `Unknown of int32 * string
+  | `Backing_file of string
+  | `Feature_name_table of string
+] with sexp
+
 type additional = {
   dirty: bool;
   corrupt: bool;
@@ -42,6 +48,7 @@ type additional = {
   refcount_order: int32;
   header_length: int32;
 } with sexp
+(** Version 3 and above have additional header fields *)
 
 type t = {
   version: Version.t;
@@ -56,7 +63,8 @@ type t = {
   refcount_table_clusters: int32; (** size of the refcount table in clusters *)
   nb_snapshots: int32;            (** the number of internal snapshots *)
   snapshots_offset: offset;       (** offset of the snapshot header *)
-  additional: additional option;    (** for version 3 or higher *)
+  additional: additional option;  (** for version 3 or higher *)
+  extensions: extension list;     (** for version 3 or higher *)
 } with sexp
 (** The qcow2 header *)
 

--- a/lib_test/error.ml
+++ b/lib_test/error.ml
@@ -1,0 +1,31 @@
+(*
+ * Copyright (C) 2016 David Scott <dave.scott@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+open Lwt.Infix
+
+type 'a error = [ `Ok of 'a | `Error of [ `Msg of string ] ]
+
+module FromBlock = struct
+  let (>>=) m f = m >>= function
+    | `Error e -> Lwt.return (`Error (`Msg (Mirage_block.Error.string_of_error e)))
+    | `Ok x -> f x
+end
+
+module Infix = struct
+  let (>>=) m f = m >>= function
+    | `Error e -> Lwt.return (`Error e)
+    | `Ok x -> f x
+end

--- a/lib_test/error.ml
+++ b/lib_test/error.ml
@@ -29,3 +29,9 @@ module Infix = struct
     | `Error e -> Lwt.return (`Error e)
     | `Ok x -> f x
 end
+
+module FromResult = struct
+  let (>>=) m f = match m with
+    | Result.Error x -> Lwt.return (`Error x)
+    | Result.Ok x -> f x
+end

--- a/lib_test/error.mli
+++ b/lib_test/error.mli
@@ -1,0 +1,30 @@
+(*
+ * Copyright (C) 2016 David Scott <dave.scott@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type 'a error = [ `Ok of 'a | `Error of [ `Msg of string ] ]
+
+module FromBlock: sig
+  val ( >>= ): [< `Error of Mirage_block.Error.error | `Ok of 'a ] Lwt.t
+    -> ('a -> ([> `Error of [> `Msg of bytes ] ] as 'b) Lwt.t)
+    -> 'b Lwt.t
+end
+
+module Infix: sig
+  val ( >>= ) : [< `Error of 'a | `Ok of 'b ] Lwt.t
+    -> ('b -> ([> `Error of 'a ] as 'c) Lwt.t)
+    -> 'c Lwt.t 
+end

--- a/lib_test/error.mli
+++ b/lib_test/error.mli
@@ -26,5 +26,10 @@ end
 module Infix: sig
   val ( >>= ) : [< `Error of 'a | `Ok of 'b ] Lwt.t
     -> ('b -> ([> `Error of 'a ] as 'c) Lwt.t)
-    -> 'c Lwt.t 
+    -> 'c Lwt.t
+end
+
+module FromResult: sig
+  val ( >>= ) :   ('a, 'b) Result.result -> ('a -> ([> `Error of 'b ] as 'c) Lwt.t) -> 'c Lwt.t
+
 end

--- a/lib_test/extent.ml
+++ b/lib_test/extent.ml
@@ -1,0 +1,71 @@
+(*
+ * Copyright (C) 2013 Citrix Inc
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+open Sexplib.Std
+open Int64
+
+type t = {
+  start: int64;
+  length: int64;
+} with sexp
+type ts = t list with sexp
+
+let to_string t = Sexplib.Sexp.to_string_hum (sexp_of_ts t)
+
+type overlap =
+  | AABB
+  | BBAA
+  | BABA
+  | BAAB
+  | ABBA
+  | ABAB
+with sexp
+
+let classify ({ start = a_start; length = a_length } as a) ({ start = b_start; length = b_length } as b) =
+  let a_end = add a_start a_length in
+  let b_end = add b_start b_length in
+  if b_end < a_start
+  then BBAA
+  else if a_end < b_start
+  then AABB
+  else begin
+    (* there is some overlap *)
+    if b_start < a_start then begin
+      if b_end < a_end then BABA else BAAB
+    end else begin
+      if b_end < a_end then ABBA else ABAB
+    end
+  end
+
+let difference ({ start = a_start; length = a_length } as a) ({ start = b_start; length = b_length } as b) =
+  let a_end = add a_start a_length in
+  let b_end = add b_start b_length in
+  match classify a b with
+  | BBAA | AABB -> [ a ]
+  | BABA -> [ { start = b_end; length = sub a_end b_end } ]
+  | BAAB -> [ ]
+  | ABBA -> [ { start = a_start; length = sub b_start a_start; };
+              { start = b_end; length = sub a_end b_end } ]
+  | ABAB -> [ { start = a_start; length = sub b_start a_start } ]
+
+let intersect ({ start = a_start; length = a_length } as a) ({ start = b_start; length = b_length } as b) : t list =
+  let a_end = add a_start a_length in
+  let b_end = add b_start b_length in
+  match classify a b with
+  | BBAA | AABB -> [ ]
+  | BABA -> [ { start = a_start; length = sub b_end a_start } ]
+  | BAAB -> [ { start = a_start; length = sub a_end a_start } ]
+  | ABBA -> [ { start = b_start; length = sub b_end b_start } ]
+  | ABAB -> [ { start = b_start; length = sub a_end b_start } ]

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -20,5 +20,45 @@ open Utils
 
 module Img = struct
   let create file size =
-    run "qemu-img" [ "create"; "-f"; "qcow2"; file; string_of_int size ]
+    ignore_output @@ run "qemu-img" [ "create"; "-f"; "qcow2"; file; string_of_int size ]
+
+  let check file =
+    run "qemu-img" [ "check"; file ]
+
+  type info = {
+    virtual_size: int;
+    filename: string;
+    cluster_size: int;
+    actual_size: int;
+    compat: string;
+    lazy_refcounts: bool;
+    refcount_bits: int;
+    corrupt: bool;
+    dirty_flag: bool;
+  }
+
+  let info file =
+    let lines, _ = run "qemu-img" [ "info"; "--output"; "json"; file ] in
+    let json = Ezjsonm.(get_dict @@ from_string @@ String.concat "\n" lines) in
+    let find name json =
+      if List.mem_assoc name json
+      then List.assoc name json
+      else failwith (Printf.sprintf "Failed to find '%s' in %s" name (String.concat "\n" lines)) in
+    let virtual_size = Ezjsonm.get_int @@ find "virtual-size" json in
+    let filename = Ezjsonm.get_string @@ find "filename" json in
+    let cluster_size = Ezjsonm.get_int @@ find "cluster-size" json in
+    let format = Ezjsonm.get_string @@ find "format" json in
+    if format <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 format, got %s" format);
+    let actual_size = Ezjsonm.get_int @@ find "actual-size" json in
+    let specific = Ezjsonm.get_dict @@ find "format-specific" json in
+    let ty = Ezjsonm.get_string @@ find "type" specific in
+    if ty <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 type, got %s" ty);
+    let data = Ezjsonm.get_dict @@ find "data" specific in
+    let compat = Ezjsonm.get_string @@ find "compat" data in
+    let lazy_refcounts = Ezjsonm.get_bool @@ find "lazy-refcounts" data in
+    let refcount_bits = Ezjsonm.get_int @@ find "refcount-bits" data in
+    let corrupt = Ezjsonm.get_bool @@ find "corrupt" data in
+    let dirty_flag = Ezjsonm.get_bool @@ find "dirty-flag" json in
+    { virtual_size; filename; cluster_size; actual_size; compat;
+      lazy_refcounts; refcount_bits; corrupt; dirty_flag }
 end

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -18,6 +18,51 @@
    ocaml-qcow images and qemu-produced images. *)
 open Utils
 
+module Img = struct
+  let create file size =
+    ignore_output @@ run "qemu-img" [ "create"; "-f"; "qcow2"; "-o"; "lazy_refcounts=on"; file; Int64.to_string size ]
+
+  let check file =
+    ignore_output @@ run "qemu-img" [ "check"; file ]
+
+  type info = {
+    virtual_size: int64;
+    filename: string;
+    cluster_size: int;
+    actual_size: int;
+    compat: string;
+    lazy_refcounts: bool option;
+    refcount_bits: int;
+    corrupt: bool option;
+    dirty_flag: bool;
+  }
+
+  let info file =
+    let lines, _ = run "qemu-img" [ "info"; "--output"; "json"; file ] in
+    let json = Ezjsonm.(get_dict @@ from_string @@ String.concat "\n" lines) in
+    let find name json =
+      if List.mem_assoc name json
+      then List.assoc name json
+      else failwith (Printf.sprintf "Failed to find '%s' in %s" name (String.concat "\n" lines)) in
+    let virtual_size = Ezjsonm.get_int64 @@ find "virtual-size" json in
+    let filename = Ezjsonm.get_string @@ find "filename" json in
+    let cluster_size = Ezjsonm.get_int @@ find "cluster-size" json in
+    let format = Ezjsonm.get_string @@ find "format" json in
+    if format <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 format, got %s" format);
+    let actual_size = Ezjsonm.get_int @@ find "actual-size" json in
+    let specific = Ezjsonm.get_dict @@ find "format-specific" json in
+    let ty = Ezjsonm.get_string @@ find "type" specific in
+    if ty <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 type, got %s" ty);
+    let data = Ezjsonm.get_dict @@ find "data" specific in
+    let compat = Ezjsonm.get_string @@ find "compat" data in
+    let lazy_refcounts = try Some (Ezjsonm.get_bool @@ find "lazy-refcounts" data) with _ -> None in
+    let refcount_bits = Ezjsonm.get_int @@ find "refcount-bits" data in
+    let corrupt = try Some (Ezjsonm.get_bool @@ find "corrupt" data) with _ -> None in
+    let dirty_flag = Ezjsonm.get_bool @@ find "dirty-flag" json in
+    { virtual_size; filename; cluster_size; actual_size; compat;
+      lazy_refcounts; refcount_bits; corrupt; dirty_flag }
+end
+
 module Block = struct
 
   type info = {
@@ -69,6 +114,10 @@ module Block = struct
     let info = { read_write; sector_size; size_sectors } in
     Lwt.return (`Ok { server; client; info })
 
+  let create file size =
+    Img.create file size;
+    connect file
+
   let disconnect { server; client } =
     let open Lwt.Infix in
     Nbd_lwt_unix.Client.disconnect client
@@ -77,49 +126,4 @@ module Block = struct
     wait server;
     Lwt.return ()
 
-end
-
-module Img = struct
-  let create file size =
-    ignore_output @@ run "qemu-img" [ "create"; "-f"; "qcow2"; file; Int64.to_string size ]
-
-  let check file =
-    ignore_output @@ run "qemu-img" [ "check"; file ]
-
-  type info = {
-    virtual_size: int64;
-    filename: string;
-    cluster_size: int;
-    actual_size: int;
-    compat: string;
-    lazy_refcounts: bool option;
-    refcount_bits: int;
-    corrupt: bool option;
-    dirty_flag: bool;
-  }
-
-  let info file =
-    let lines, _ = run "qemu-img" [ "info"; "--output"; "json"; file ] in
-    let json = Ezjsonm.(get_dict @@ from_string @@ String.concat "\n" lines) in
-    let find name json =
-      if List.mem_assoc name json
-      then List.assoc name json
-      else failwith (Printf.sprintf "Failed to find '%s' in %s" name (String.concat "\n" lines)) in
-    let virtual_size = Ezjsonm.get_int64 @@ find "virtual-size" json in
-    let filename = Ezjsonm.get_string @@ find "filename" json in
-    let cluster_size = Ezjsonm.get_int @@ find "cluster-size" json in
-    let format = Ezjsonm.get_string @@ find "format" json in
-    if format <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 format, got %s" format);
-    let actual_size = Ezjsonm.get_int @@ find "actual-size" json in
-    let specific = Ezjsonm.get_dict @@ find "format-specific" json in
-    let ty = Ezjsonm.get_string @@ find "type" specific in
-    if ty <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 type, got %s" ty);
-    let data = Ezjsonm.get_dict @@ find "data" specific in
-    let compat = Ezjsonm.get_string @@ find "compat" data in
-    let lazy_refcounts = try Some (Ezjsonm.get_bool @@ find "lazy-refcounts" data) with _ -> None in
-    let refcount_bits = Ezjsonm.get_int @@ find "refcount-bits" data in
-    let corrupt = try Some (Ezjsonm.get_bool @@ find "corrupt" data) with _ -> None in
-    let dirty_flag = Ezjsonm.get_bool @@ find "dirty-flag" json in
-    { virtual_size; filename; cluster_size; actual_size; compat;
-      lazy_refcounts; refcount_bits; corrupt; dirty_flag }
 end

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -106,6 +106,8 @@ module Block = struct
         (fun _ ->
           Lwt_unix.sleep 0.1
           >>= fun () ->
+          Lwt_unix.close s
+          >>= fun () ->
           connect ()) in
     connect ()
     >>= fun s ->

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) 2016 Unikernel Systems
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* Wrappers for qemu-img, qemu-nbd to allow us to compare the contents of
+   ocaml-qcow images and qemu-produced images. *)
+open Utils
+
+module Img = struct
+  let create file size =
+    run "qemu-img" [ "create"; "-f"; "qcow2"; file; string_of_int size ]
+end

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -92,9 +92,9 @@ module Img = struct
     cluster_size: int;
     actual_size: int;
     compat: string;
-    lazy_refcounts: bool;
+    lazy_refcounts: bool option;
     refcount_bits: int;
-    corrupt: bool;
+    corrupt: bool option;
     dirty_flag: bool;
   }
 
@@ -116,9 +116,9 @@ module Img = struct
     if ty <> "qcow2" then failwith (Printf.sprintf "Expected qcow2 type, got %s" ty);
     let data = Ezjsonm.get_dict @@ find "data" specific in
     let compat = Ezjsonm.get_string @@ find "compat" data in
-    let lazy_refcounts = Ezjsonm.get_bool @@ find "lazy-refcounts" data in
+    let lazy_refcounts = try Some (Ezjsonm.get_bool @@ find "lazy-refcounts" data) with _ -> None in
     let refcount_bits = Ezjsonm.get_int @@ find "refcount-bits" data in
-    let corrupt = Ezjsonm.get_bool @@ find "corrupt" data in
+    let corrupt = try Some (Ezjsonm.get_bool @@ find "corrupt" data) with _ -> None in
     let dirty_flag = Ezjsonm.get_bool @@ find "dirty-flag" json in
     { virtual_size; filename; cluster_size; actual_size; compat;
       lazy_refcounts; refcount_bits; corrupt; dirty_flag }

--- a/lib_test/qemu.mli
+++ b/lib_test/qemu.mli
@@ -1,0 +1,49 @@
+(*
+ * Copyright (C) 2016 Unikernel Systems
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Wrappers for qemu-img, qemu-nbd to allow us to compare the contents of
+   ocaml-qcow images and qemu-produced images. *)
+
+module Block : sig
+  include V1_LWT.BLOCK
+
+  val connect: string -> [ `Ok of t ] Lwt.t
+  (** [connect path] connects to a BLOCK device exported by qemu-nbd *)
+end
+
+module Img: sig
+
+  val create: string -> int64 -> unit
+  (** [create path size] creates a qcow2 format image at [path] with size [size] *)
+
+  val check: string -> unit
+  (** [check path] runs "qemu-img check" on the given qcow2 image. *)
+
+  type info = {
+    virtual_size: int64;
+    filename: string;
+    cluster_size: int;
+    actual_size: int;
+    compat: string;
+    lazy_refcounts: bool option;
+    refcount_bits: int;
+    corrupt: bool option;
+    dirty_flag: bool;
+  }
+
+  val info: string -> info
+  (** [info path] returns metadata associated with the given qcow2 image. *)
+end

--- a/lib_test/qemu.mli
+++ b/lib_test/qemu.mli
@@ -22,6 +22,10 @@ module Block : sig
 
   val connect: string -> [ `Ok of t ] Lwt.t
   (** [connect path] connects to a BLOCK device exported by qemu-nbd *)
+
+  val create: string -> int64 -> [ `Ok of t ] Lwt.t
+  (** [create path size] creates an image using qemu-img and then connects
+      to it via qemu-nbd *)
 end
 
 module Img: sig

--- a/lib_test/sizes.ml
+++ b/lib_test/sizes.ml
@@ -1,0 +1,71 @@
+(*
+ * Copyright (C) 2013 Citrix Inc
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+module FromBlock = Error.FromBlock
+
+open Sexplib.Std
+open Qcow
+open Lwt
+open OUnit
+open Utils
+
+let mib = Int64.mul 1024L 1024L
+let gib = Int64.mul mib 1024L
+let tib = Int64.mul gib 1024L
+let pib = Int64.mul tib 1024L
+
+let boundaries cluster_bits =
+  let cluster_size = Int64.shift_left 1L cluster_bits in
+  let pointers_in_cluster = Int64.(div cluster_size 8L) in [
+    "0", 0L;
+    Printf.sprintf "one %Ld byte cluster" cluster_size, cluster_size;
+    Printf.sprintf "one L2 table (containing %Ld 8-byte pointers to cluster)"
+      pointers_in_cluster,
+    Int64.(mul cluster_size pointers_in_cluster);
+    Printf.sprintf "one L1 table (containing %Ld 8-byte pointers to L2 tables)"
+      pointers_in_cluster,
+    Int64.(mul (mul cluster_size pointers_in_cluster) pointers_in_cluster)
+  ]
+
+let sizes sector_size cluster_bits = [
+  "one sector", Int64.of_int sector_size;
+  "one page", 4096L;
+  "one cluster", Int64.shift_left 1L cluster_bits;
+]
+
+let off_by ((label', offset'), (label, offset)) = [
+  label, offset;
+  label ^ " + " ^ label', Int64.add offset offset';
+  label ^ " - " ^ label', Int64.sub offset offset';
+  label ^ " + 2 * " ^ label', Int64.(add offset (mul 2L offset'));
+]
+
+let rec cross xs ys = match xs, ys with
+  | [], ys -> []
+  | x :: xs, ys -> List.map (fun y -> x, y) ys @ (cross xs ys)
+
+(* Parameterise over sector, page, cluster, more *)
+let interesting_ranges sector_size size_sectors cluster_bits =
+  let size_bytes = Int64.(mul size_sectors (of_int sector_size)) in
+  let starts = List.concat (List.map off_by (cross (sizes sector_size cluster_bits) (boundaries cluster_bits))) in
+  let all = starts @ (List.map (fun (label, offset) -> label ^ " from the end", Int64.sub size_bytes offset) starts) in
+  (* add lengths *)
+  let all = List.map (fun ((label', length'), (label, offset)) ->
+      label' ^ " @ " ^ label, offset, length'
+    ) (cross (sizes sector_size cluster_bits) all) in
+  List.filter
+    (fun (label, offset, length) ->
+       offset >= 0L && (Int64.add offset length <= size_bytes)
+    ) all

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -242,13 +242,7 @@ let write_read_qemu sector_size size_sectors (start, length) () =
     >>= fun () ->
     Qemu.Img.check path;
     check_file_contents path id sector_size size_sectors (start, length) () in
-  try
     or_failwith @@ Lwt_main.run t
-  with e ->
-    Printf.fprintf stderr "STOP %s\n%!" (Printexc.to_string e);
-    Printexc.print_backtrace stderr;
-    Printf.fprintf stderr "%s\n%!" path;
-    exit 1
 
 let check_refcount_table_allocation () =
   let module B = Qcow.Make(Ramdisk) in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -20,7 +20,7 @@ open Qcow
 open Lwt
 open OUnit
 open Utils
-
+open Sizes
 
 let expect_ok = function
   | `Error _ -> failwith "IO failure"
@@ -87,11 +87,6 @@ let create_1M () =
   let printer = Qcow.Header.to_string in
   assert_equal ~printer ~cmp expected hdr
 
-let mib = Int64.mul 1024L 1024L
-let gib = Int64.mul mib 1024L
-let tib = Int64.mul gib 1024L
-let pib = Int64.mul tib 1024L
-
 let create_1P () =
   let hdr = read_write_header "1P" pib in
   let expected = {
@@ -105,50 +100,6 @@ let create_1P () =
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
   assert_equal ~printer ~cmp expected hdr
-
-let boundaries cluster_bits =
-  let cluster_size = Int64.shift_left 1L cluster_bits in
-  let pointers_in_cluster = Int64.(div cluster_size 8L) in [
-    "0", 0L;
-    Printf.sprintf "one %Ld byte cluster" cluster_size, cluster_size;
-    Printf.sprintf "one L2 table (containing %Ld 8-byte pointers to cluster)"
-      pointers_in_cluster,
-    Int64.(mul cluster_size pointers_in_cluster);
-    Printf.sprintf "one L1 table (containing %Ld 8-byte pointers to L2 tables)"
-      pointers_in_cluster,
-    Int64.(mul (mul cluster_size pointers_in_cluster) pointers_in_cluster)
-  ]
-
-let sizes sector_size cluster_bits = [
-  "one sector", Int64.of_int sector_size;
-  "one page", 4096L;
-  "one cluster", Int64.shift_left 1L cluster_bits;
-]
-
-let off_by ((label', offset'), (label, offset)) = [
-  label, offset;
-  label ^ " + " ^ label', Int64.add offset offset';
-  label ^ " - " ^ label', Int64.sub offset offset';
-  label ^ " + 2 * " ^ label', Int64.(add offset (mul 2L offset'));
-]
-
-let rec cross xs ys = match xs, ys with
-  | [], ys -> []
-  | x :: xs, ys -> List.map (fun y -> x, y) ys @ (cross xs ys)
-
-(* Parameterise over sector, page, cluster, more *)
-let interesting_ranges sector_size size_sectors cluster_bits =
-  let size_bytes = Int64.(mul size_sectors (of_int sector_size)) in
-  let starts = List.concat (List.map off_by (cross (sizes sector_size cluster_bits) (boundaries cluster_bits))) in
-  let all = starts @ (List.map (fun (label, offset) -> label ^ " from the end", Int64.sub size_bytes offset) starts) in
-  (* add lengths *)
-  let all = List.map (fun ((label', length'), (label, offset)) ->
-      label' ^ " @ " ^ label, offset, length'
-    ) (cross (sizes sector_size cluster_bits) all) in
-  List.filter
-    (fun (label, offset, length) ->
-       offset >= 0L && (Int64.add offset length <= size_bytes)
-    ) all
 
 let get_id =
   let next = ref 1 in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -59,6 +59,7 @@ let create_1K () =
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -72,6 +73,7 @@ let create_1M () =
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -90,6 +92,7 @@ let create_1P () =
     crypt_method = `None; l1_size = 2097152l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -369,6 +369,13 @@ let qemu_img size =
     >>= fun () ->
     Block.disconnect b
     >>= fun () ->
+    let open FromBlock in
+    (* Check the qemu-nbd wrapper works *)
+    Qemu.Block.connect path
+    >>= fun block ->
+    let open Lwt.Infix in
+    Qemu.Block.disconnect block
+    >>= fun () ->
     Lwt.return (`Ok ()) in
   or_failwith @@ Lwt_main.run t
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -352,6 +352,9 @@ let test_dir =
 let qemu_img size =
   let path = Filename.concat test_dir (string_of_int size) in
   Qemu.Img.create path size;
+  let info = Qemu.Img.info path in
+  assert_equal ~printer:string_of_int size info.Qemu.Img.virtual_size;
+  Qemu.Img.check path;
   let t =
     let module M = Qcow.Make(Block) in
     let open FromBlock in
@@ -370,8 +373,8 @@ let qemu_img size =
   or_failwith @@ Lwt_main.run t
 
 let qemu_img_suite = List.map (fun size ->
-  Printf.sprintf "check that qemu-img creates files and we can read the metadata, size = %d bytes" size >:: (fun () -> qemu_img size)
-)
+    Printf.sprintf "check that qemu-img creates files and we can read the metadata, size = %d bytes" size >:: (fun () -> qemu_img size)
+  )
 
 let _ =
   let sector_size = 512 in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -374,6 +374,10 @@ let qemu_img size =
     Qemu.Block.connect path
     >>= fun block ->
     let open Lwt.Infix in
+    Qemu.Block.get_info block
+    >>= fun info ->
+    let size = Int64.(mul info.Qemu.Block.size_sectors (of_int info.Qemu.Block.sector_size)) in
+    assert_equal ~printer:Int64.to_string size size;
     Qemu.Block.disconnect block
     >>= fun () ->
     Lwt.return (`Ok ()) in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -51,14 +51,22 @@ let read_write_header name size =
       Lwt.return hdr in
   Lwt_main.run t
 
+let additional = Some {
+  Qcow.Header.dirty = true;
+  corrupt = false;
+  lazy_refcounts = true;
+  autoclear_features = 0L;
+  refcount_order = 4l;
+}
+
 let create_1K () =
   let hdr = read_write_header "1K" 1024L in
   let expected = {
-    Qcow.Header.version = `Two; backing_file_offset = 0L;
+    Qcow.Header.version = `Three; backing_file_offset = 0L;
     backing_file_size = 0l; cluster_bits = 16l; size = 1024L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional;
     extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
@@ -68,11 +76,11 @@ let create_1K () =
 let create_1M () =
   let hdr = read_write_header "1M" 1048576L in
   let expected = {
-    Qcow.Header.version = `Two; backing_file_offset = 0L;
+    Qcow.Header.version = `Three; backing_file_offset = 0L;
     backing_file_size = 0l; cluster_bits = 16l; size = 1048576L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional;
     extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
@@ -87,11 +95,11 @@ let pib = Int64.mul tib 1024L
 let create_1P () =
   let hdr = read_write_header "1P" pib in
   let expected = {
-    Qcow.Header.version = `Two; backing_file_offset = 0L;
+    Qcow.Header.version = `Three; backing_file_offset = 0L;
     backing_file_size = 0l; cluster_bits = 16l; size = pib;
     crypt_method = `None; l1_size = 2097152l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional;
     extensions = [];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -58,7 +58,7 @@ let create_1K () =
     backing_file_size = 0l; cluster_bits = 16l; size = 1024L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -71,7 +71,7 @@ let create_1M () =
     backing_file_size = 0l; cluster_bits = 16l; size = 1048576L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -89,7 +89,7 @@ let create_1P () =
     backing_file_size = 0l; cluster_bits = 16l; size = pib;
     crypt_method = `None; l1_size = 2097152l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
+    nb_snapshots = 0l; snapshots_offset = 0L; additional = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -159,6 +159,8 @@ let read_write sector_size size_sectors (start, length) () =
     let cmp a b = Cstruct.compare a b = 0 in
     assert_equal ~printer:(fun x -> String.escaped (Cstruct.to_string x)) ~cmp buf buf';
 
+    Qemu.Img.check path;
+
     (* This is the range that we expect to see written *)
     let expected = { Extent.start = sector; length = Int64.(div (of_int length) 512L) } in
     let ofs' = Int64.(mul sector (of_int sector_size)) in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -58,7 +58,7 @@ let create_1K () =
     backing_file_size = 0l; cluster_bits = 16l; size = 1024L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L
+    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -71,7 +71,7 @@ let create_1M () =
     backing_file_size = 0l; cluster_bits = 16l; size = 1048576L;
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L
+    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -89,7 +89,7 @@ let create_1P () =
     backing_file_size = 0l; cluster_bits = 16l; size = pib;
     crypt_method = `None; l1_size = 2097152l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
-    nb_snapshots = 0l; snapshots_offset = 0L
+    nb_snapshots = 0l; snapshots_offset = 0L; extension = None;
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -52,4 +52,4 @@ let run cmd args =
   let out = read_lines oc in
   let err = read_lines ec in
   let exit_status = Unix.close_process_full (oc, ic, ec) in
-  ignore_output @@ or_failwith @@ check_exit_status cmdline (out, err) exit_status
+  or_failwith @@ check_exit_status cmdline (out, err) exit_status

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -37,25 +37,35 @@ let or_failwith = function
 
 let ignore_output (_: (string list * string list)) = ()
 
-type process = (in_channel * out_channel * in_channel) * string
+type process = int * (in_channel * out_channel * in_channel) * string
 
 let check_exit_status cmdline = function
   | Unix.WEXITED 0 -> `Ok ()
-  | _ -> debug "%s failed" cmdline; `Error (`Msg cmdline)
+  | Unix.WEXITED n -> debug "%s failed" cmdline; `Error (`Msg (cmdline ^ ": " ^ (string_of_int n)))
 
 let start cmd args : process =
-  let args' = List.map (fun x -> "'" ^ (String.escaped x) ^ "'") args in
-  let cmdline = Printf.sprintf "%s %s " cmd (String.concat " " args') in
-  debug "%s" cmdline;
-  Unix.open_process_full cmdline (Unix.environment ()), cmdline
+  let stdin_r, stdin_w = Unix.pipe () in
+  let stdout_r, stdout_w = Unix.pipe () in
+  let stderr_r, stderr_w = Unix.pipe () in
+  let pid = Unix.create_process cmd (Array.of_list (cmd :: args)) stdin_r stdout_w stderr_w in
+  Unix.close stdin_r;
+  Unix.close stdout_w;
+  Unix.close stderr_w;
+  let ic = Unix.out_channel_of_descr stdin_w in
+  let oc = Unix.in_channel_of_descr stdout_r in
+  let ec = Unix.in_channel_of_descr stderr_r in
+  pid, (oc, ic, ec), Printf.sprintf "%s %s" cmd (String.concat " " args)
 
-let wait ((oc, ic, ec), cmdline) =
-  let exit_status = Unix.close_process_full (oc, ic, ec) in
+let wait (pid, (oc, ic, ec), cmdline) =
+  close_out ic;
+  close_in oc;
+  close_in ec;
+  let _, exit_status = Unix.waitpid [] pid in
   or_failwith @@ check_exit_status cmdline exit_status
 
 let run cmd args =
-  let (oc, ic, ec), cmdline = start cmd args in
+  let pid, (oc, ic, ec), cmdline = start cmd args in
   let out = read_lines oc in
   let err = read_lines ec in
-  wait ((oc, ic, ec), cmdline);
+  wait (pid, (oc, ic, ec), cmdline);
   out, err

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -42,6 +42,8 @@ type process = int * (in_channel * out_channel * in_channel) * string
 let check_exit_status cmdline = function
   | Unix.WEXITED 0 -> `Ok ()
   | Unix.WEXITED n -> debug "%s failed" cmdline; `Error (`Msg (cmdline ^ ": " ^ (string_of_int n)))
+  | Unix.WSIGNALED n -> debug "%s killed by signal %d" cmdline n; `Error (`Msg (cmdline ^ " killed by signal %d" ^ (string_of_int n)))
+  | Unix.WSTOPPED n -> debug "%s stopped by signal %d" cmdline n; `Error (`Msg (cmdline ^ " stopped by signal %d" ^ (string_of_int n)))
 
 let start cmd args : process =
   let stdin_r, stdin_w = Unix.pipe () in

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -1,0 +1,55 @@
+(*
+ * Copyright (C) 2016 Unikernel Systems
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+let debug fmt =
+  Printf.ksprintf (fun s ->
+      Printf.fprintf stderr "%s\n%!" s
+    ) fmt
+
+let check_exit_status cmd (out, err) status =
+  if out <> [] then debug "stdout: %s" (String.concat "\n" out);
+  if err <> [] then debug "stderr: %s" (String.concat "\n" err);
+  match status with
+  | Unix.WEXITED 0   -> `Ok (out, err)
+  | _ -> debug "%s failed" cmd; `Error (`Msg cmd)
+
+let read_lines oc =
+  let rec aux acc =
+    let line =
+      try Some (input_line oc)
+      with End_of_file -> None
+    in
+    match line with
+    | Some l -> aux (l :: acc)
+    | None   -> List.rev acc
+  in
+  aux []
+
+let or_failwith = function
+  | `Ok x -> x
+  | `Error (`Msg m) -> failwith m
+
+let ignore_output (_: (string list * string list)) = ()
+
+let run cmd args =
+  let args' = List.map (fun x -> "'" ^ (String.escaped x) ^ "'") args in
+  let cmdline = Printf.sprintf "%s %s " cmd (String.concat " " args') in
+  debug "%s" cmdline;
+  let oc, ic, ec = Unix.open_process_full cmdline (Unix.environment ()) in
+  let out = read_lines oc in
+  let err = read_lines ec in
+  let exit_status = Unix.close_process_full (oc, ic, ec) in
+  ignore_output @@ or_failwith @@ check_exit_status cmdline (out, err) exit_status

--- a/opam
+++ b/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "qcow"
+name: "qcow-format"
 maintainer: "dave@recoil.org"
 version: "0.1"
 authors: [ "David Scott" ]

--- a/opam
+++ b/opam
@@ -35,7 +35,7 @@ depends: [
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}
-  "nbd" {>= "2.0.0"} {test}
+  "nbd" {test & >= "2.0.0"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 

--- a/opam
+++ b/opam
@@ -35,6 +35,7 @@ depends: [
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}
+  "nbd" {>= "2.0.0"} {test}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 

--- a/opam
+++ b/opam
@@ -35,7 +35,7 @@ depends: [
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}
-  "nbd" {test}
+  "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 

--- a/opam
+++ b/opam
@@ -35,7 +35,7 @@ depends: [
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}
-  "nbd" {test & >= "2.0.0"}
+  "nbd" {test}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 

--- a/opam
+++ b/opam
@@ -34,6 +34,7 @@ depends: [
   "oasis" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}
+  "ezjsonm" {test}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 


### PR DESCRIPTION
We wish to ensure this library is compatible with qemu. These patches add some testing wrappers around qemu commands which we'll exploit in future patches.