### PR TITLE
Use ppx rather than camlp4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ dist: trusty
 env:
   global:
     - PACKAGE="qcow-format" OCAML_VERSION=4.02
+    - PINS="nbd"
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+0.3 (2016-05-12)
+- Depend on ppx, require OCaml 4.02+
+
 0.2 (2016-01-15)
 - Use qcow version 3 by default, setting `lazy_refcount=on`
 - Unit tests now verify that `qemu-img check` is happy and that `qemu-nbd`

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library qcow
   Path:               lib
   Findlibname:        qcow
   Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual, Qcow_physical, Qcow
-  BuildDepends:       result, cstruct, sexplib, sexplib.syntax, mirage-types.lwt, lwt, io-page
+  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page
 
 Document qcow
   Title:                Qcow docs

--- a/_oasis
+++ b/_oasis
@@ -38,7 +38,7 @@ Executable test
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm, nbd, nbd.lwt
+  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm, nbd, nbd.lwt, ppx_sexp_conv
 
 Test test
   Run$:               flag(tests)

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        qcow
-Version:     0.2
+Version:     0.3
 Synopsis:    Qcow2 image format
 Authors:     David Scott
 License:     ISC

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -28,7 +28,7 @@ module Version = struct
     | `One
     | `Two
     | `Three
-  ] with sexp
+  ] [@@deriving sexp]
 
   let sizeof t = 4
 
@@ -49,7 +49,7 @@ end
 
 module CryptMethod = struct
 
-  type t = [ `Aes | `None ] with sexp
+  type t = [ `Aes | `None ] [@@deriving sexp]
 
   let sizeof _ = 4
 
@@ -67,13 +67,13 @@ module CryptMethod = struct
   let compare (a: t) (b: t) = compare a b
 end
 
-type offset = int64 with sexp
+type offset = int64 [@@deriving sexp]
 
 type extension = [
   | `Unknown of int32 * string
   | `Backing_file of string
   | `Feature_name_table of string
-] with sexp
+] [@@deriving sexp]
 
 type additional = {
   dirty: bool;
@@ -81,7 +81,7 @@ type additional = {
   lazy_refcounts: bool;
   autoclear_features: int64;
   refcount_order: int32;
-} with sexp
+} [@@deriving sexp]
 
 type t = {
   version: Version.t;
@@ -98,7 +98,7 @@ type t = {
   snapshots_offset: offset;
   additional: additional option;
   extensions: extension list;
-} with sexp
+} [@@deriving sexp]
 
 let compare (a: t) (b: t) = compare a b
 

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -20,13 +20,13 @@ module Version : sig
     | `One
     | `Two
     | `Three
-  ] with sexp
+  ] [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
 end
 
 module CryptMethod : sig
-  type t = [ `Aes | `None ] with sexp
+  type t = [ `Aes | `None ] [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
 end
@@ -38,7 +38,7 @@ type extension = [
   | `Unknown of int32 * string
   | `Backing_file of string
   | `Feature_name_table of string
-] with sexp
+] [@@deriving sexp]
 
 type additional = {
   dirty: bool;
@@ -46,7 +46,7 @@ type additional = {
   lazy_refcounts: bool;
   autoclear_features: int64;
   refcount_order: int32;
-} with sexp
+} [@@deriving sexp]
 (** Version 3 and above have additional header fields *)
 
 type t = {
@@ -64,7 +64,7 @@ type t = {
   snapshots_offset: offset;       (** offset of the snapshot header *)
   additional: additional option;  (** for version 3 or higher *)
   extensions: extension list;     (** for version 3 or higher *)
-} with sexp
+} [@@deriving sexp]
 (** The qcow2 header *)
 
 val refcounts_per_cluster: t -> int64

--- a/lib/qcow_physical.ml
+++ b/lib/qcow_physical.ml
@@ -28,8 +28,7 @@ type t = {
   bytes: int64;
   is_mutable: bool;
   is_compressed: bool;
-}
-with sexp
+} [@@deriving sexp]
 
 let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 

--- a/lib/qcow_physical.mli
+++ b/lib/qcow_physical.mli
@@ -19,7 +19,7 @@
    - represent 0L as a None
    	*)
 
-type t with sexp
+type t [@@deriving sexp]
 (** A physical address within the backing disk *)
 
 val is_compressed: t -> bool

--- a/lib/qcow_types.ml
+++ b/lib/qcow_types.ml
@@ -24,7 +24,7 @@ let big_enough_for name buf needed =
   else return ()
 
 module Int8 = struct
-  type t = int with sexp
+  type t = int [@@deriving sexp]
 
   let sizeof _ = 1
 
@@ -41,7 +41,7 @@ module Int8 = struct
 end
 
 module Int16 = struct
-  type t = int with sexp
+  type t = int [@@deriving sexp]
 
   let sizeof _ = 2
 
@@ -60,7 +60,7 @@ end
 module Int32 = struct
   include Int32
 
-  type _t = int32 with sexp
+  type _t = int32 [@@deriving sexp]
   let sexp_of_t = sexp_of__t
   let t_of_sexp = _t_of_sexp
 
@@ -81,7 +81,7 @@ end
 module Int64 = struct
   include Int64
 
-  type _t = int64 with sexp
+  type _t = int64 [@@deriving sexp]
   let sexp_of_t = sexp_of__t
   let t_of_sexp = _t_of_sexp
 

--- a/lib/qcow_types.mli
+++ b/lib/qcow_types.mli
@@ -24,13 +24,13 @@ val big_enough_for: string -> Cstruct.t -> int -> unit Qcow_error.t
     in the error message. *)
 
 module Int8 : sig
-  type t = int with sexp
+  type t = int [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
 end
 
 module Int16 : sig
-  type t = int with sexp
+  type t = int [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
 end

--- a/lib/qcow_virtual.ml
+++ b/lib/qcow_virtual.ml
@@ -21,7 +21,7 @@ type t = {
   l1_index: int64; (* index in the L1 table *)
   l2_index: int64; (* index in the L2 table *)
   cluster: int64;  (* index within the cluster *)
-} with sexp
+} [@@deriving sexp]
 
 let ( <| ) = Int64.shift_left
 let ( |> ) = Int64.shift_right_logical

--- a/lib/qcow_virtual.mli
+++ b/lib/qcow_virtual.mli
@@ -19,7 +19,7 @@ type t = {
   l1_index: int64; (* index in the L1 table *)
   l2_index: int64; (* index in the L2 table *)
   cluster: int64;  (* index within the cluster *)
-} with sexp
+} [@@deriving sexp]
 (** A virtual address in a qcow image is broken into 3 levels:
     - an index in the L1 table, pointing to
     		 - an index in the L2 table, pointing to

--- a/lib_test/extent.ml
+++ b/lib_test/extent.ml
@@ -19,8 +19,8 @@ open Int64
 type t = {
   start: int64;
   length: int64;
-} with sexp
-type ts = t list with sexp
+} [@@deriving sexp]
+type ts = t list [@@deriving sexp]
 
 let to_string t = Sexplib.Sexp.to_string_hum (sexp_of_ts t)
 
@@ -31,7 +31,7 @@ type overlap =
   | BAAB
   | ABBA
   | ABAB
-with sexp
+[@@deriving sexp]
 
 let classify ({ start = a_start; length = a_length } as a) ({ start = b_start; length = b_length } as b) =
   let a_end = add a_start a_length in

--- a/opam
+++ b/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-version: "0.1"
+version: "0.3"
 authors: [ "David Scott" ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"

--- a/opam
+++ b/opam
@@ -32,6 +32,9 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "oasis" {build}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}


### PR DESCRIPTION
- use `ppx_sexp_conv` rather than `sexplib.syntax`
- bump version to 0.3

Fixes #18 (although now will need a fairly new sexplib)