### PR TITLE
Support buffered/out-of-sync block devices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+0.4 (2016-08-03)
+- For buffered block devices, call `flush` to guarantee metadata correctness
+
 0.3 (2016-05-12)
 - Depend on ppx, require OCaml 4.02+
 

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        qcow
-Version:     0.3
+Version:     0.4
 Synopsis:    Qcow2 image format
 Authors:     David Scott
 License:     ISC

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library qcow
   Path:               lib
   Findlibname:        qcow
   Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual, Qcow_physical, Qcow
-  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page
+  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page, logs
 
 Document qcow
   Title:                Qcow docs
@@ -29,7 +29,8 @@ Executable "qcow-tool"
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, qcow, cmdliner, cstruct.lwt, mirage-block-unix, mirage-block, io-page.unix
+  BuildDepends:       lwt, lwt.unix, qcow, cmdliner, cstruct.lwt, logs.fmt,
+    mirage-block-unix, mirage-block, io-page.unix
 
 Executable test
   Build$:             flag(tests)

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -194,6 +194,7 @@ let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
   write_cmd; read_cmd]
 
 let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
   match Term.eval_choice default_cmd cmds with
   | `Error _ -> exit 1
   | _ -> exit 0

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -757,6 +757,8 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     (* Write an initial empty L1 table *)
     B.write base Int64.(div l1_table_offset (of_int t.base_info.B.sector_size)) [ cluster ]
     >>*= fun () ->
+    B.flush base
+    >>*= fun () ->
     Lwt.return (`Ok t)
 
   let rebuild_refcount_table t =

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -61,6 +61,10 @@ module type RESIZABLE_BLOCK = sig
 
   val resize: t -> int64 -> [ `Ok of unit | `Error of error ] Lwt.t
   (** Resize the file to the given number of sectors. *)
+
+  val flush : t -> [ `Ok of unit | `Error of error ] io
+  (** [flush t] flushes any buffers, if the file has been opened in buffered
+      mode *)
 end
 
 module type DEBUG = sig

--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depends: [
   "mirage-block-unix" {>= "2.1.0" }
   "cmdliner"
   "sexplib"
+  "logs"
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}

--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depends: [
   "cmdliner"
   "sexplib"
   "logs"
+  "fmt"
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}

--- a/opam
+++ b/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-version: "0.3"
 authors: [ "David Scott" ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"


### PR DESCRIPTION
We now require a `BLOCK` device which includes a `flush` function which we will call at key points to ensure qcow metadata is persisted. Note it is still the user's responsibility to call `flush` to persist user data in this case.

Prepare to release v0.4