### PR TITLE
Flush and use lazy refcounts properly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 0.4 (2016-08-03)
 - For buffered block devices, call `flush` to guarantee metadata correctness
+- In lazy_refcounts mode (the default), do not compute any refcounts
+- CLI: the `repair` command should recompute refcounts
 
 0.3 (2016-05-12)
 - Depend on ppx, require OCaml 4.02+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+0.4 (2016-08-03)
+- For buffered block devices, call `flush` to guarantee metadata correctness
+
 0.3 (2016-05-12)
 - Depend on ppx, require OCaml 4.02+
 

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,8 @@ Library qcow
   Path:               lib
   Findlibname:        qcow
   Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual, Qcow_physical, Qcow
-  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page, logs
+  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt,
+    lwt, io-page, logs, astring
 
 Document qcow
   Title:                Qcow docs

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        qcow
-Version:     0.3
+Version:     0.4
 Synopsis:    Qcow2 image format
 Authors:     David Scott
 License:     ISC

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library qcow
   Path:               lib
   Findlibname:        qcow
   Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual, Qcow_physical, Qcow
-  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page
+  BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt, lwt, io-page, logs
 
 Document qcow
   Title:                Qcow docs
@@ -29,7 +29,8 @@ Executable "qcow-tool"
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, qcow, cmdliner, cstruct.lwt, mirage-block-unix, mirage-block, io-page.unix
+  BuildDepends:       lwt, lwt.unix, qcow, cmdliner, cstruct.lwt, logs.fmt,
+    mirage-block-unix, mirage-block, io-page.unix
 
 Executable test
   Build$:             flag(tests)

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -186,7 +186,7 @@ let encode filename output =
       >>= function
       | `Error _ -> failwith (Printf.sprintf "Failed to open %s" output)
       | `Ok raw_output ->
-        B.create raw_output total_size
+        B.create raw_output ~size:total_size ()
         >>= function
         | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" output)
         | `Ok qcow_output ->
@@ -198,7 +198,7 @@ let encode filename output =
           | `Ok () -> return (`Ok ()) in
   Lwt_main.run t
 
-let create size filename =
+let create size strict_refcounts filename =
   let module B = Qcow.Make(Block) in
   let open Lwt in
   let t =
@@ -210,7 +210,7 @@ let create size filename =
     >>= function
     | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
     | `Ok x ->
-      B.create x size
+      B.create x ~size ~lazy_refcounts:(not strict_refcounts) ()
       >>= function
       | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" filename)
       | `Ok x -> return (`Ok ()) in

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -102,6 +102,10 @@ let output =
   let doc = Printf.sprintf "Path to the output file." in
   Arg.(value & pos 0 string "test.raw" & info [] ~doc)
 
+let trace =
+  let doc = Printf.sprintf "Print block device accesses for debugging" in
+  Arg.(value & flag & info [ "trace" ] ~doc)
+
 let info_cmd =
   let doc = "display general information about a qcow2" in
   let man = [
@@ -144,7 +148,7 @@ let create_cmd =
     `S "DESCRIPTION";
     `P "Create a qcow-formatted data file";
   ] @ help in
-  Term.(ret(pure Impl.create $ size $ strict_refcounts $ output)),
+  Term.(ret(pure Impl.create $ size $ strict_refcounts $ trace $ output)),
   Term.info "create" ~sdocs:_common_options ~doc ~man
 
 let unsafe_buffering =

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -194,6 +194,7 @@ let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
   write_cmd; read_cmd]
 
 let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
   match Term.eval_choice default_cmd cmds with
   | `Error _ -> exit 1
   | _ -> exit 0

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -180,7 +180,7 @@ let write_cmd =
     `S "DESCRIPTION";
     `P "Write a string at a given virtual sector offset in the qcow2 image."
   ] @ help in
-  Term.(ret(pure Impl.write $ filename $ sector $ text)),
+  Term.(ret(pure Impl.write $ filename $ sector $ text $ trace)),
   Term.info "write" ~sdocs:_common_options ~doc ~man
 
 let length =
@@ -193,7 +193,7 @@ let read_cmd =
     `S "DESCRIPTION";
     `P "Read a string at a given virtual sector offset in the qcow2 image."
   ] @ help in
-  Term.(ret(pure Impl.read $ filename $ sector $ length)),
+  Term.(ret(pure Impl.read $ filename $ sector $ length $ trace)),
   Term.info "read" ~sdocs:_common_options ~doc ~man
 
 let default_cmd =

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -94,6 +94,10 @@ let size =
   let doc = Printf.sprintf "Virtual size of the qcow image" in
   Arg.(value & opt size_converter 1024L & info [ "size" ] ~doc)
 
+let strict_refcounts =
+  let doc = Printf.sprintf "Use strict (non-lazy) refcounts" in
+  Arg.(value & flag & info [ "strict-refcounts" ] ~doc)
+
 let output =
   let doc = Printf.sprintf "Path to the output file." in
   Arg.(value & pos 0 string "test.raw" & info [] ~doc)
@@ -140,7 +144,7 @@ let create_cmd =
     `S "DESCRIPTION";
     `P "Create a qcow-formatted data file";
   ] @ help in
-  Term.(ret(pure Impl.create $ size $ output)),
+  Term.(ret(pure Impl.create $ size $ strict_refcounts $ output)),
   Term.info "create" ~sdocs:_common_options ~doc ~man
 
 let repair_cmd =

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -147,6 +147,10 @@ let create_cmd =
   Term.(ret(pure Impl.create $ size $ strict_refcounts $ output)),
   Term.info "create" ~sdocs:_common_options ~doc ~man
 
+let unsafe_buffering =
+  let doc = Printf.sprintf "Run faster by caching writes in memory. A failure in the middle could corrupt the file." in
+  Arg.(value & flag & info [ "unsafe-buffering" ] ~doc)
+
 let repair_cmd =
   let doc = "Regenerate the refcount table in an image" in
   let man = [
@@ -155,7 +159,7 @@ let repair_cmd =
     the spec. We normally avoid updating the refcount at runtime as a
     performance optimisation."
   ] @ help in
-  Term.(ret(pure Impl.repair $ filename)),
+  Term.(ret(pure Impl.repair $ unsafe_buffering $ filename)),
   Term.info "repair" ~sdocs:_common_options ~doc ~man
 
 let sector =

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -525,8 +525,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
                let data_offset = Physical.make (data_cluster <| t.cluster_bits) in
                write_l2_table t l2_offset a.Virtual.l2_index data_offset
                >>*= fun () ->
-               B.flush t.base
-               >>*= fun () ->
                write_l1_table t a.Virtual.l1_index l2_offset
                >>*= fun () ->
                B.flush t.base

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -809,9 +809,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     (* Disable lazy refcounts so we actually update the real refcounts *)
     let lazy_refcounts = t.lazy_refcounts in
     t.lazy_refcounts <- false;
-
     (* Zero all clusters allocated in the refcount table *)
-    let buf = malloc t.h in
     let cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits (Physical.make t.h.Header.refcount_table_offset) in
     let rec loop i =
       if i >= Int64.of_int32 t.h.Header.refcount_table_clusters

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -907,13 +907,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
             ( if Physical.to_bytes addr <> 0L then begin
                 let cluster', _ = Physical.to_cluster ~cluster_bits:t.cluster_bits addr in
                 Log.debug (fun f -> f "L1 cluster %Ld has reference to L2 cluster %Ld" cluster cluster');
-                (* It might have been incremented already by a previous `incr` *)
-                Cluster.Refcount.read t cluster'
-                >>*= function
-                | 0 ->
-                  Cluster.Refcount.incr t cluster'
-                | _ ->
-                  Lwt.return (`Ok ())
+                Cluster.Refcount.incr t cluster'
               end else Lwt.return (`Ok ()) )
             >>*= fun () ->
             inner (8 + i)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -931,9 +931,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
       let refcount_table_offset = Physical.make t.h.Header.refcount_table_offset in
       let refcount_table_cluster, within = Physical.to_cluster ~cluster_bits:t.cluster_bits refcount_table_offset in
       assert (within = 0);
-      (* This will `assert` if any cluster has a refcount >1 *)
-      rebuild_refcount_table t
-      >>*= fun () ->
       Lwt.return (`Ok ())
 
     let set_next_cluster t x = t.next_cluster <- x

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -887,7 +887,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
       let refs_per_cluster = 1L <| (t.cluster_bits - 3) in
       Int64.(div (round_up (of_int32 t.h.Header.l1_size) refs_per_cluster) refs_per_cluster) in
     let l1_table_cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits (Physical.make t.h.Header.l1_table_offset) in
-    let loop i =
+    let rec loop i =
       if i >= l1_table_clusters
       then Lwt.return (`Ok ())
       else begin

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -764,7 +764,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
       autoclear_features = 0L;
       refcount_order = 4l;
       } in
-    let extensions = [] in
+    let extensions = [
+      `Feature_name_table Header.Feature.understood
+    ] in
     let h = {
       Header.version; backing_file_offset; backing_file_size;
       cluster_bits = Int32.of_int cluster_bits; size; crypt_method;

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -940,7 +940,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
           >>*= function
           | None -> assert false
           | Some offset' ->
-            let cluster, _ = Physical.to_sector ~sector_size:t.sector_size offset' in
+            let cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits offset' in
             Cluster.Refcount.incr t cluster
             >>*= fun () ->
             loop (Int64.add mapped_sector sectors_per_cluster)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -757,6 +757,8 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     (* Write an initial empty L1 table *)
     B.write base Int64.(div l1_table_offset (of_int t.base_info.B.sector_size)) [ cluster ]
     >>*= fun () ->
+    B.flush base
+    >>*= fun () ->
     Lwt.return (`Ok t)
 
   let rebuild_refcount_table t =

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -734,7 +734,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     then Lwt.return (`Error (`Unknown "I don't know how to resize in the case where the L1 table needs new clusters:"))
     else update_header t { t.h with Header.l1_size = Int64.to_int32 l2_tables_required }
 
-  let create base size =
+  let create base ~size ?(lazy_refcounts=true) () =
     let version = `Three in
     let backing_file_offset = 0L in
     let backing_file_size = 0l in
@@ -752,9 +752,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     let nb_snapshots = 0l in
     let snapshots_offset = 0L in
     let additional = Some {
-      Header.dirty = true;
+      Header.dirty = lazy_refcounts;
       corrupt = false;
-      lazy_refcounts = true;
+      lazy_refcounts;
       autoclear_features = 0L;
       refcount_order = 4l;
       } in

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -20,9 +20,12 @@ module Header = Qcow_header
 module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
   include V1_LWT.BLOCK
 
-  val create: B.t -> int64 -> [ `Ok of t | `Error of error ] io
-  (** [create block size] initialises a qcow-formatted image on [block]
-      with virtual size [size] in bytes. *)
+  val create: B.t -> size:int64 -> ?lazy_refcounts:bool -> unit
+      -> [ `Ok of t | `Error of error ] io
+  (** [create block ~size ?lazy_refcounts ()] initialises a qcow-formatted
+      image on [block] with virtual size [size] in bytes. By default the file
+      will use lazy refcounts, but this can be overriden by supplying
+      [~lazy_refcounts:false] *)
 
   val connect: B.t -> [ `Ok of t | `Error of error ] io
   (** [connect block] connects to an existing qcow-formatted image on

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -31,13 +31,39 @@ module CryptMethod : sig
   include Qcow_s.SERIALISABLE with type t := t
 end
 
+module Feature : sig
+  type ty = [
+    | `Incompatible
+    | `Compatible
+    | `Autoclear
+  ]
+
+  type feature = [
+    | `Corrupt
+    | `Dirty
+    | `Lazy_refcounts
+    | `Unknown of string
+  ]
+
+  type t = {
+    ty: ty;
+    bit: int;
+    feature: feature;
+  }
+
+  val understood: t list
+  (** The features understood by this implementation *)
+
+  include Qcow_s.SERIALISABLE with type t := t
+end
+
 type offset = int64
 (** Offset within the image *)
 
 type extension = [
   | `Unknown of int32 * string
   | `Backing_file of string
-  | `Feature_name_table of string
+  | `Feature_name_table of Feature.t list
 ] [@@deriving sexp]
 
 type additional = {

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -61,6 +61,10 @@ module type RESIZABLE_BLOCK = sig
 
   val resize: t -> int64 -> [ `Ok of unit | `Error of error ] Lwt.t
   (** Resize the file to the given number of sectors. *)
+
+  val flush : t -> [ `Ok of unit | `Error of error ] io
+  (** [flush t] flushes any buffers, if the file has been opened in buffered
+      mode *)
 end
 
 module type DEBUG = sig

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -32,7 +32,7 @@ module Img = struct
     actual_size: int;
     compat: string;
     lazy_refcounts: bool option;
-    refcount_bits: int;
+    refcount_bits: int option;
     corrupt: bool option;
     dirty_flag: bool;
   }
@@ -56,7 +56,7 @@ module Img = struct
     let data = Ezjsonm.get_dict @@ find "data" specific in
     let compat = Ezjsonm.get_string @@ find "compat" data in
     let lazy_refcounts = try Some (Ezjsonm.get_bool @@ find "lazy-refcounts" data) with _ -> None in
-    let refcount_bits = Ezjsonm.get_int @@ find "refcount-bits" data in
+    let refcount_bits = try Some (Ezjsonm.get_int @@ find "refcount-bits" data) with _ -> None in
     let corrupt = try Some (Ezjsonm.get_bool @@ find "corrupt" data) with _ -> None in
     let dirty_flag = Ezjsonm.get_bool @@ find "dirty-flag" json in
     { virtual_size; filename; cluster_size; actual_size; compat;

--- a/lib_test/qemu.mli
+++ b/lib_test/qemu.mli
@@ -43,7 +43,7 @@ module Img: sig
     actual_size: int;
     compat: string;
     lazy_refcounts: bool option;
-    refcount_bits: int;
+    refcount_bits: int option;
     corrupt: bool option;
     dirty_flag: bool;
   }

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -343,6 +343,11 @@ let check_file path size =
   >>= fun qcow ->
   let h = M.header qcow in
   assert_equal ~printer:Int64.to_string size h.Qcow.Header.size;
+  let dirty =
+    match h.Qcow.Header.additional with
+    | Some { Qcow.Header.dirty = true } -> true
+    | _ -> false in
+  assert_equal ~printer:string_of_bool dirty info.Qemu.Img.dirty_flag;
   let open Lwt.Infix in
   M.disconnect qcow
   >>= fun () ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -71,7 +71,7 @@ let read_write_header name size =
     let open FromBlock in
     Block.connect path
     >>= fun raw ->
-    B.create raw size
+    B.create raw ~size ()
     >>= fun b ->
     let open Lwt.Infix in
     repair_refcounts path
@@ -214,7 +214,7 @@ let write_read_native sector_size size_sectors (start, length) () =
     let open FromBlock in
     RawWriter.connect path
     >>= fun raw ->
-    Writer.create raw Int64.(mul size_sectors (of_int sector_size))
+    Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ()
     >>= fun b ->
 
     let sector = Int64.div start 512L in
@@ -278,7 +278,7 @@ let check_refcount_table_allocation () =
     let open FromBlock in
     Ramdisk.connect "test"
     >>= fun ramdisk ->
-    B.create ramdisk pib
+    B.create ramdisk ~size:pib ()
     >>= fun b ->
 
     let h = B.header b in
@@ -300,7 +300,7 @@ let check_full_disk () =
     let open FromBlock in
     Ramdisk.connect "test"
     >>= fun ramdisk ->
-    B.create ramdisk gib
+    B.create ramdisk ~size:gib ()
     >>= fun b ->
 
     let open Lwt.Infix in
@@ -383,7 +383,7 @@ let qcow_tool size =
     let open FromBlock in
     Block.connect path
     >>= fun block ->
-    B.create block size
+    B.create block ~size ()
     >>= fun qcow ->
     let open Lwt.Infix in
     B.disconnect qcow

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -63,7 +63,7 @@ let repair_refcounts path =
 
 let read_write_header name size =
   let module B = Qcow.Make(Block) in
-  let path = Filename.concat test_dir (Printf.sprintf "%s.%Ld" name size) in
+  let path = Filename.concat test_dir (Printf.sprintf "read_write_header.%s.%Ld" name size) in
 
   let t =
     truncate path
@@ -206,7 +206,7 @@ let check_file_contents path id sector_size size_sectors (start, length) () =
 let write_read_native sector_size size_sectors (start, length) () =
   let module RawWriter = Block in
   let module Writer = Qcow.Make(RawWriter) in
-  let path = Filename.concat test_dir (Printf.sprintf "%Ld.%Ld.%d" size_sectors start length) in
+  let path = Filename.concat test_dir (Printf.sprintf "write_read_native.%Ld.%Ld.%d" size_sectors start length) in
 
   let t =
     truncate path
@@ -242,7 +242,7 @@ let write_read_native sector_size size_sectors (start, length) () =
 let write_read_qemu sector_size size_sectors (start, length) () =
   let module RawWriter = Block in
   let module Writer = Qemu.Block in
-  let path = Filename.concat test_dir (Printf.sprintf "%Ld.%Ld.%d" size_sectors start length) in
+  let path = Filename.concat test_dir (Printf.sprintf "write_read_qemu.%Ld.%Ld.%d" size_sectors start length) in
 
   let t =
     truncate path

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -104,7 +104,7 @@ let create_1K () =
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional;
-    extensions = [];
+    extensions = [ `Feature_name_table Qcow.Header.Feature.understood ];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -118,7 +118,7 @@ let create_1M () =
     crypt_method = `None; l1_size = 1l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional;
-    extensions = [];
+    extensions = [ `Feature_name_table Qcow.Header.Feature.understood ];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -132,7 +132,7 @@ let create_1P () =
     crypt_method = `None; l1_size = 2097152l; l1_table_offset = 131072L;
     refcount_table_offset = 65536L; refcount_table_clusters = 1l;
     nb_snapshots = 0l; snapshots_offset = 0L; additional;
-    extensions = [];
+    extensions = [ `Feature_name_table Qcow.Header.Feature.understood ];
   } in
   let cmp a b = Qcow.Header.compare a b = 0 in
   let printer = Qcow.Header.to_string in
@@ -347,7 +347,10 @@ let check_file path size =
     match h.Qcow.Header.additional with
     | Some { Qcow.Header.dirty = true } -> true
     | _ -> false in
+  (* Unfortunately qemu-img info doesn't query the dirty flag:
+     https://github.com/djs55/qemu/commit/9ac8f24fde855c66b1378cee30791a4aef5c33ba
   assert_equal ~printer:string_of_bool dirty info.Qemu.Img.dirty_flag;
+  *)
   let open Lwt.Infix in
   M.disconnect qcow
   >>= fun () ->

--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depends: [
   "mirage-block-unix" {>= "2.1.0" }
   "cmdliner"
   "sexplib"
+  "logs"
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}

--- a/opam
+++ b/opam
@@ -31,6 +31,7 @@ depends: [
   "sexplib"
   "logs"
   "fmt"
+  "astring"
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}

--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depends: [
   "cmdliner"
   "sexplib"
   "logs"
+  "fmt"
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}

--- a/opam
+++ b/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-version: "0.3"
 authors: [ "David Scott" ]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"


### PR DESCRIPTION
We now require a `BLOCK` device which includes a `flush` function which we will call at key points to ensure qcow metadata is persisted. Note it is still the user's responsibility to call `flush` to persist user data in this case.

When lazy refcounting is requested (the default) we do not maintain refcount tables at all. Running `qemu-img check` will highlight the missing refcounts. The `qcow-tool repair` command will rebuild the refcount tables such that `qemu-img check` will be happy.

This PR also fixes bugs in the `seek_mapped` function, highlighted by its use in `repair`.

Prepare to release v0.4