### PR TITLE
Remove an unnecessary call to flush

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.4.1 (2016-08-17)
+- Remove one necessary source of `flush` calls
+- CLI: add `mapped` command to list the mapped regions of a file
+
 0.4 (2016-08-03)
 - For buffered block devices, call `flush` to guarantee metadata correctness
 - In lazy_refcounts mode (the default), do not compute any refcounts

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        qcow
-Version:     0.4
+Version:     0.4.1
 Synopsis:    Qcow2 image format
 Authors:     David Scott
 License:     ISC

--- a/_oasis
+++ b/_oasis
@@ -31,7 +31,7 @@ Executable "qcow-tool"
   Custom:             true
   Install:            false
   BuildDepends:       lwt, lwt.unix, qcow, cmdliner, cstruct.lwt, logs.fmt,
-    mirage-block-unix, mirage-block, io-page.unix
+    mirage-block-unix, mirage-block, io-page.unix, astring
 
 Executable test
   Build$:             flag(tests)

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -16,6 +16,7 @@
  *)
 open Sexplib.Std
 open Result
+open Astring
 
 let project_url = "http://github.com/djs55/ocaml-qcow"
 
@@ -59,18 +60,14 @@ let sizes = List.sort (fun (_, a) (_, b) -> compare a b) [
 ]
 
 let size_parser txt =
-  let endswith suffix txt =
-    let suffix' = String.length suffix in
-    let txt' = String.length txt in
-    txt' >= suffix' && (String.sub txt (txt' - suffix') suffix' = suffix) in
   let prefix suffix txt =
     let suffix' = String.length suffix in
     let txt' = String.length txt in
-    String.sub txt 0 (txt' - suffix') in
+    String.with_range ~len:(txt' - suffix') txt in
   try
     match List.fold_left (fun acc (suffix, multiplier) -> match acc with
       | Some x -> Some x
-      | None when not(endswith suffix txt) -> None
+      | None when not(String.is_suffix ~affix:suffix txt) -> None
       | None -> Some (Int64.(mul multiplier (of_string (prefix suffix txt))))
     ) None sizes with
     | None -> `Ok (Int64.of_string txt)


### PR DESCRIPTION
We don't need to flush after every allocation since if any of the writes are dropped, it will be as if the allocation never happened (modulo the size of the file)