### PR TITLE
CLI: don't break the build if Block.connect has optional arguments

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -43,6 +43,13 @@ let to_cmdliner_error = function
   | `Error (`Unknown x) -> `Error(false, x)
   | `Ok x -> `Ok x
 
+module Block = struct
+  include Block
+  (* We're not interested in any optional arguments [connect] may or may not
+     have *)
+  let connect path = connect path
+end
+
 module TracedBlock = struct
   include Block
 


### PR DESCRIPTION
See [mirage/mirage-block-unix#52]

Signed-off-by: David Scott <dave@recoil.org>