### PR TITLE
connect no longer returns a result type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 dist: trusty
 env:
   global:
+    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
     - PACKAGE="qcow-format" OCAML_VERSION=4.02
     - PINS="nbd"
     - COV_CONF="export TESTS=--enable-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ env:
   global:
     - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
     - PACKAGE="qcow-format" OCAML_VERSION=4.02
-    - PINS="nbd"
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module Qcow_on_ramdisk :                                                        
       t ->
       int64 -> page_aligned_buffer list -> [ `Error of error | `Ok of unit ] io
     val create : Ramdisk.t -> int64 -> [ `Error of error | `Ok of t ] io
-    val connect : Ramdisk.t -> [ `Error of error | `Ok of t ] io
+    val connect : Ramdisk.t -> t io
     val resize : t -> int64 -> [ `Error of error | `Ok of unit ] io
     val seek_unmapped : t -> int64 -> [ `Error of error | `Ok of int64 ] io
     val seek_mapped : t -> int64 -> [ `Error of error | `Ok of int64 ] io

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -77,7 +77,7 @@ module type BLOCK = sig
 
   include Qcow_s.RESIZABLE_BLOCK
 
-  val connect: string -> [ `Ok of t | `Error of error ] Lwt.t
+  val connect: string -> t Lwt.t
 end
 
 module UnsafeBlock = struct
@@ -113,21 +113,17 @@ let write filename sector data trace =
   let t =
     let open Lwt in
     BLOCK.connect filename
+    >>= fun x ->
+    B.connect x
+    >>= fun x ->
+    let npages = (String.length data + 4095) / 4096 in
+    let buf = Io_page.(to_cstruct (get npages)) in
+    Cstruct.memset buf 0;
+    Cstruct.blit_from_string data 0 buf 0 (String.length data);
+    B.write x sector [ buf ]
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok x ->
-      B.connect x
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to read qcow formatted data on %s" filename)
-      | `Ok x ->
-        let npages = (String.length data + 4095) / 4096 in
-        let buf = Io_page.(to_cstruct (get npages)) in
-        Cstruct.memset buf 0;
-        Cstruct.blit_from_string data 0 buf 0 (String.length data);
-        B.write x sector [ buf ]
-        >>= function
-        | `Error _ -> failwith "write failed"
-        | `Ok () -> return (`Ok ()) in
+    | `Error _ -> failwith "write failed"
+    | `Ok () -> return (`Ok ()) in
   Lwt_main.run t
 
 let read filename sector length trace =
@@ -140,23 +136,19 @@ let read filename sector length trace =
   let t =
     let open Lwt in
     BLOCK.connect filename
+    >>= fun x ->
+    B.connect x
+    >>= fun x ->
+    let length = Int64.to_int length * 512 in
+    let npages = (length + 4095) / 4096 in
+    let buf = Io_page.(to_cstruct (get npages)) in
+    B.read x sector [ buf ]
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok x ->
-      B.connect x
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to read qcow formatted data on %s" filename)
-      | `Ok x ->
-        let length = Int64.to_int length * 512 in
-        let npages = (length + 4095) / 4096 in
-        let buf = Io_page.(to_cstruct (get npages)) in
-        B.read x sector [ buf ]
-        >>= function
-        | `Error _ -> failwith "write failed"
-        | `Ok () ->
-          let result = Cstruct.sub buf 0 length in
-          Printf.printf "%s%!" (Cstruct.to_string result);
-          return (`Ok ()) in
+    | `Error _ -> failwith "write failed"
+    | `Ok () ->
+      let result = Cstruct.sub buf 0 length in
+      Printf.printf "%s%!" (Cstruct.to_string result);
+      return (`Ok ()) in
   Lwt_main.run t
 
 let check filename =
@@ -164,20 +156,16 @@ let check filename =
   let open Lwt in
   let t =
     Block.connect filename
+    >>= fun x ->
+    B.connect x
+    >>= fun x ->
+    Mirage_block.fold_s ~f:(fun acc ofs buf ->
+        return ()
+      ) () (module B) x
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok x ->
-      B.connect x
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to read qcow formatted data on %s" filename)
-      | `Ok x ->
-        Mirage_block.fold_s ~f:(fun acc ofs buf ->
-          return ()
-        ) () (module B) x
-        >>= function
-        | `Error (`Msg m) -> failwith m
-        | `Ok () ->
-          return (`Ok ()) in
+    | `Error (`Msg m) -> failwith m
+    | `Ok () ->
+      return (`Ok ()) in
   Lwt_main.run t
 
 
@@ -191,9 +179,9 @@ let repair unsafe_buffering filename =
   let open Lwt in
   let t =
     BLOCK.connect filename
-    >>*= fun x ->
+    >>= fun x ->
     B.connect x
-    >>*= fun x ->
+    >>= fun x ->
     B.rebuild_refcount_table x
     >>*= fun () ->
     B.Debug.check_no_overlaps x
@@ -206,30 +194,24 @@ let decode filename output =
   let open Lwt in
   let t =
     Block.connect filename
+    >>= fun x ->
+    B.connect x
+    >>= fun x ->
+    B.get_info x
+    >>= fun info ->
+    let total_size = Int64.(mul info.B.size_sectors (of_int info.B.sector_size)) in
+    Lwt_unix.openfile output [ Lwt_unix.O_WRONLY; Lwt_unix.O_CREAT ] 0o0644
+    >>= fun fd ->
+    Lwt_unix.LargeFile.ftruncate fd total_size
+    >>= fun () ->
+    Lwt_unix.close fd
+    >>= fun () ->
+    Block.connect output
+    >>= fun y ->
+    Mirage_block.sparse_copy (module B) x (module Block) y
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok x ->
-      B.connect x
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to read qcow formatted data on %s" filename)
-      | `Ok x ->
-        B.get_info x
-        >>= fun info ->
-        let total_size = Int64.(mul info.B.size_sectors (of_int info.B.sector_size)) in
-        Lwt_unix.openfile output [ Lwt_unix.O_WRONLY; Lwt_unix.O_CREAT ] 0o0644
-        >>= fun fd ->
-        Lwt_unix.LargeFile.ftruncate fd total_size
-        >>= fun () ->
-        Lwt_unix.close fd
-        >>= fun () ->
-        Block.connect output
-        >>= function
-        | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-        | `Ok y ->
-          Mirage_block.sparse_copy (module B) x (module Block) y
-          >>= function
-          | `Error _ -> failwith "copy failed"
-          | `Ok () -> return (`Ok ()) in
+    | `Error _ -> failwith "copy failed"
+    | `Ok () -> return (`Ok ()) in
   Lwt_main.run t
 
 let encode filename output =
@@ -237,30 +219,26 @@ let encode filename output =
   let open Lwt in
   let t =
     Block.connect filename
+    >>= fun raw_input ->
+    Block.get_info raw_input
+    >>= fun raw_input_info ->
+    let total_size = Int64.(mul raw_input_info.Block.size_sectors (of_int raw_input_info.Block.sector_size)) in
+    Lwt_unix.openfile output [ Lwt_unix.O_WRONLY; Lwt_unix.O_CREAT ] 0o0644
+    >>= fun fd ->
+    Lwt_unix.close fd
+    >>= fun () ->
+    Block.connect output
+    >>= fun raw_output ->
+    B.create raw_output ~size:total_size ()
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok raw_input ->
-      Block.get_info raw_input
-      >>= fun raw_input_info ->
-      let total_size = Int64.(mul raw_input_info.Block.size_sectors (of_int raw_input_info.Block.sector_size)) in
-      Lwt_unix.openfile output [ Lwt_unix.O_WRONLY; Lwt_unix.O_CREAT ] 0o0644
-      >>= fun fd ->
-      Lwt_unix.close fd
-      >>= fun () ->
-      Block.connect output
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to open %s" output)
-      | `Ok raw_output ->
-        B.create raw_output ~size:total_size ()
-        >>= function
-        | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" output)
-        | `Ok qcow_output ->
+    | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" output)
+    | `Ok qcow_output ->
 
-          Mirage_block.sparse_copy (module Block) raw_input (module B) qcow_output
-          >>= function
-          | `Error (`Msg m) -> failwith m
-          | `Error _ -> failwith "copy failed"
-          | `Ok () -> return (`Ok ()) in
+      Mirage_block.sparse_copy (module Block) raw_input (module B) qcow_output
+      >>= function
+      | `Error (`Msg m) -> failwith m
+      | `Error _ -> failwith "copy failed"
+      | `Ok () -> return (`Ok ()) in
   Lwt_main.run t
 
 let create size strict_refcounts trace filename =
@@ -277,13 +255,11 @@ let create size strict_refcounts trace filename =
     Lwt_unix.close fd
     >>= fun () ->
     BLOCK.connect filename
+    >>= fun x ->
+    B.create x ~size ~lazy_refcounts:(not strict_refcounts) ()
     >>= function
-    | `Error _ -> failwith (Printf.sprintf "Failed to open %s" filename)
-    | `Ok x ->
-      B.create x ~size ~lazy_refcounts:(not strict_refcounts) ()
-      >>= function
-      | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" filename)
-      | `Ok x -> return (`Ok ()) in
+    | `Error _ -> failwith (Printf.sprintf "Failed to create qcow formatted data on %s" filename)
+    | `Ok x -> return (`Ok ()) in
   Lwt_main.run t
 
 type output = [
@@ -301,9 +277,9 @@ let mapped filename format ignore_zeroes =
   let open Lwt in
   let t =
     Block.connect filename
-    >>*= fun x ->
+    >>= fun x ->
     B.connect x
-    >>*= fun x ->
+    >>= fun x ->
     B.get_info x
     >>= fun info ->
     Printf.printf "# offset (bytes), length (bytes)\n";

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -43,7 +43,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
     size_sectors : int64;
   }
 
-  type id = B.id
   type page_aligned_buffer = B.page_aligned_buffer
 
   let (>>*=) m f =

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -27,7 +27,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
       will use lazy refcounts, but this can be overriden by supplying
       [~lazy_refcounts:false] *)
 
-  val connect: B.t -> [ `Ok of t | `Error of error ] io
+  val connect: B.t -> t io
   (** [connect block] connects to an existing qcow-formatted image on
       [block]. *)
 

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -121,7 +121,7 @@ module Block = struct
     let sector_size = 512 in
     let size_sectors = Int64.(div size (of_int sector_size)) in
     let info = { read_write; sector_size; size_sectors } in
-    Lwt.return (`Ok { server; client; s; info })
+    Lwt.return ({ server; client; s; info })
 
   let create file size =
     Img.create file size;

--- a/lib_test/qemu.mli
+++ b/lib_test/qemu.mli
@@ -20,10 +20,10 @@
 module Block : sig
   include V1_LWT.BLOCK
 
-  val connect: string -> [ `Ok of t ] Lwt.t
+  val connect: string -> t Lwt.t
   (** [connect path] connects to a BLOCK device exported by qemu-nbd *)
 
-  val create: string -> int64 -> [ `Ok of t ] Lwt.t
+  val create: string -> int64 -> t Lwt.t
   (** [create path size] creates an image using qemu-img and then connects
       to it via qemu-nbd *)
 end

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -41,11 +41,11 @@ let test_dir =
 let repair_refcounts path =
   let module B = Qcow.Make(Block) in
   let t =
-    let open FromBlock in
     Block.connect path
     >>= fun raw ->
     B.connect raw
     >>= fun qcow ->
+    let open FromBlock in
     B.rebuild_refcount_table qcow
     >>= fun () ->
     let open Lwt.Infix in
@@ -68,9 +68,9 @@ let read_write_header name size =
   let t =
     truncate path
     >>= fun () ->
-    let open FromBlock in
     Block.connect path
     >>= fun raw ->
+    let open FromBlock in
     B.create raw ~size ()
     >>= fun b ->
     let open Lwt.Infix in
@@ -162,13 +162,13 @@ let check_file_contents path id sector_size size_sectors (start, length) () =
   let module Reader = Qcow.Make(RawReader) in
   let sector = Int64.div start 512L in
   (* This is the range that we expect to see written *)
-  let open FromBlock in
   RawReader.connect path
   >>= fun raw ->
   Reader.connect raw
   >>= fun b ->
   let expected = { Extent.start = sector; length = Int64.(div (of_int length) 512L) } in
   let ofs' = Int64.(mul sector (of_int sector_size)) in
+  let open FromBlock in
   Mirage_block.fold_mapped_s
     ~f:(fun bytes_seen ofs data ->
         let actual = { Extent.start = ofs; length = Int64.of_int (Cstruct.len data / 512) } in
@@ -211,9 +211,9 @@ let write_read_native sector_size size_sectors (start, length) () =
   let t =
     truncate path
     >>= fun () ->
-    let open FromBlock in
     RawWriter.connect path
     >>= fun raw ->
+    let open FromBlock in
     Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ()
     >>= fun b ->
 
@@ -247,10 +247,10 @@ let write_read_qemu sector_size size_sectors (start, length) () =
   let t =
     truncate path
     >>= fun () ->
-    let open FromBlock in
     Writer.create path Int64.(mul size_sectors (of_int sector_size))
     >>= fun b ->
 
+    let open FromBlock in
     let sector = Int64.div start 512L in
     let id = get_id () in
     let buf = malloc length in
@@ -275,9 +275,9 @@ let check_refcount_table_allocation () =
   let module B = Qcow.Make(Ramdisk) in
   let t =
     Ramdisk.destroy ~name:"test";
-    let open FromBlock in
     Ramdisk.connect "test"
     >>= fun ramdisk ->
+    let open FromBlock in
     B.create ramdisk ~size:pib ()
     >>= fun b ->
 
@@ -297,9 +297,9 @@ let check_full_disk () =
   let module B = Qcow.Make(Ramdisk) in
   let t =
     Ramdisk.destroy ~name:"test";
-    let open FromBlock in
     Ramdisk.connect "test"
     >>= fun ramdisk ->
+    let open FromBlock in
     B.create ramdisk ~size:gib ()
     >>= fun b ->
 
@@ -336,11 +336,11 @@ let check_file path size =
   repair_refcounts path
   >>= fun () ->
   Qemu.Img.check path;
-  let open FromBlock in
   Block.connect path
   >>= fun b ->
   M.connect b
   >>= fun qcow ->
+  let open FromBlock in
   let h = M.header qcow in
   assert_equal ~printer:Int64.to_string size h.Qcow.Header.size;
   let dirty =
@@ -356,11 +356,9 @@ let check_file path size =
   >>= fun () ->
   Block.disconnect b
   >>= fun () ->
-  let open FromBlock in
   (* Check the qemu-nbd wrapper works *)
   Qemu.Block.connect path
   >>= fun block ->
-  let open Lwt.Infix in
   Qemu.Block.get_info block
   >>= fun info ->
   let size = Int64.(mul info.Qemu.Block.size_sectors (of_int info.Qemu.Block.sector_size)) in
@@ -388,9 +386,9 @@ let qcow_tool size =
   let t =
     truncate path
     >>= fun () ->
-    let open FromBlock in
     Block.connect path
     >>= fun block ->
+    let open FromBlock in
     B.create block ~size ()
     >>= fun qcow ->
     let open Lwt.Infix in


### PR DESCRIPTION
needs https://github.com/xapi-project/nbd/pull/28

tests run on my laptop... but I've no clue about this library, code review would be appreciated.

I also modified in lib_test Qemu.create to return `t io` instead of `(`Ok t) io`, there are likely more return types which can be adjusted (not sure why connect calls read, and I've to handle these errors manually, but previously it also failed hard if an error occured; maybe connect should call some read_internal which doesn't return an ``Error`).
