### PR TITLE
Add a --filter argument to info

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -99,11 +99,6 @@ let info filename filter =
       | None -> original_sexp
       | Some str -> Sexplib.Path.get ~str original_sexp in
     Printf.printf "%s\n" (Sexplib.Sexp.to_string_hum sexp);
-    Printf.printf "Max clusters: %Ld\n" (Int64.shift_right h.Header.size (Int32.to_int h.Header.cluster_bits));
-
-    Printf.printf "Refcounts per cluster: %Ld\n" (Header.refcounts_per_cluster h);
-    Printf.printf "Max refcount table size: %Ld\n" (Header.max_refcount_table_size h);
-
     return (`Ok ()) in
   Lwt_main.run t
 

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -85,7 +85,7 @@ module UnsafeBlock = struct
   let flush _ = Lwt.return (`Ok ())
 end
 
-let info filename =
+let info filename filter =
   let t =
     let open Lwt in
     Lwt_unix.openfile filename [ Lwt_unix.O_RDONLY ] 0
@@ -94,7 +94,11 @@ let info filename =
     Lwt_cstruct.complete (Lwt_cstruct.read fd) buffer
     >>= fun () ->
     let h, _ = expect_ok (Header.read buffer) in
-    Printf.printf "%s\n" (Sexplib.Sexp.to_string_hum (Header.sexp_of_t h));
+    let original_sexp = Header.sexp_of_t h in
+    let sexp = match filter with
+      | None -> original_sexp
+      | Some str -> Sexplib.Path.get ~str original_sexp in
+    Printf.printf "%s\n" (Sexplib.Sexp.to_string_hum sexp);
     Printf.printf "Max clusters: %Ld\n" (Int64.shift_right h.Header.size (Int32.to_int h.Header.cluster_bits));
 
     Printf.printf "Refcounts per cluster: %Ld\n" (Header.refcounts_per_cluster h);

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -18,7 +18,7 @@ open Sexplib.Std
 open Result
 open Astring
 
-let project_url = "http://github.com/djs55/ocaml-qcow"
+let project_url = "http://github.com/mirage/ocaml-qcow"
 
 open Cmdliner
 

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -128,13 +128,23 @@ let ignore_zeroes =
   let doc = "Scan for and ignore blocks which are full of zeroes" in
   Arg.(value & flag & info [ "ignore-zeroes" ] ~doc)
 
+let filter =
+  let doc = "Path within the structure" in
+  Arg.(value & opt (some string) None & info [ "filter" ] ~doc)
+
 let info_cmd =
   let doc = "display general information about a qcow2" in
   let man = [
     `S "DESCRIPTION";
     `P "Display the contents of a qcow2 file header.";
+    `P "By default the full header is printed as an s-expression. To print only some fields provide a --filter argument.";
+    `S "EXAMPLES";
+    `P "To print the file size:";
+    `P "$(mname) info <filename> --filter .size";
+    `P "To print the dirty flag:";
+    `P "$(mname) info <filename> --filter .additional.[0].dirty";
   ] @ help in
-  Term.(ret(pure Impl.info $ filename)),
+  Term.(ret(pure Impl.info $ filename $ filter)),
   Term.info "info" ~sdocs:_common_options ~doc ~man
 
 let check_cmd =


### PR DESCRIPTION
This makes it easier to query qcow2 header metadata from scripts. For example:
```
$ qcow-tool info 1K.qcow2 --filter .additional.[0].dirty
true
$ qcow-tool info 1K.qcow2 --filter .size
1024
```