### PR TITLE
Add support for `discard` aka TRIM

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -12,7 +12,8 @@ Library qcow
   CompiledObject:     best
   Path:               lib
   Findlibname:        qcow
-  Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual, Qcow_physical, Qcow
+  Modules:            Qcow_s, Qcow_header, Qcow_error, Qcow_types, Qcow_virtual,
+    Qcow_physical, Qcow_diet, Qcow
   BuildDepends:       result, cstruct, sexplib, ppx_sexp_conv, mirage-types.lwt,
     lwt, io-page, logs, astring
 

--- a/_oasis
+++ b/_oasis
@@ -47,3 +47,12 @@ Test test
   Run$:               flag(tests)
   Command:            $test -runner sequential
   WorkingDirectory:   lib_test
+
+Executable test_random
+  Build$:             flag(tests)
+  CompiledObject:     best
+  Path:               lib_test
+  MainIs:             compact_random.ml
+  Custom:             true
+  Install:            false
+  BuildDepends:       lwt, lwt.unix, qcow, mirage-block, mirage-block-ramdisk, mirage-block-unix, cstruct, oUnit, io-page.unix, io-page, ezjsonm, nbd, nbd.lwt, ppx_sexp_conv

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -15,6 +15,9 @@
  *
  *)
 
-type t = bool
+type t = {
+  debug: bool;
+  progress: bool;
+}
 
-let make t = t
+let make debug progress = { debug; progress }

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -279,6 +279,7 @@ let compact common_options_t unsafe_buffering filename =
   let module BLOCK = (val block: BLOCK) in
   let module B = Qcow.Make(BLOCK) in
   let open Lwt in
+  let progress_cb = if common_options_t.progress then Some progress_cb else None in
   let t =
     BLOCK.connect filename
     >>*= fun x ->
@@ -286,7 +287,7 @@ let compact common_options_t unsafe_buffering filename =
     >>*= fun x ->
     B.get_info x
     >>= fun info ->
-    B.compact x ~progress_cb ()
+    B.compact x ?progress_cb ()
     >>*= fun report ->
     if report.B.old_size = report.B.new_size
     then Printf.printf "I couldn't make the file any smaller. Consider running `discard`.\n"

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -85,6 +85,15 @@ module UnsafeBlock = struct
   let flush _ = Lwt.return (`Ok ())
 end
 
+let handle_common common_options_t =
+  if common_options_t then begin
+    List.iter
+      (fun src ->
+        if Logs.Src.name src = "qcow"
+        then Logs.Src.set_level src (Some Logs.Debug)
+      ) (Logs.Src.list ())
+  end
+
 let info filename filter =
   let t =
     let open Lwt in
@@ -239,7 +248,8 @@ let discard unsafe_buffering filename =
     return (`Ok ()) in
   Lwt_main.run (t >>= fun r -> return (to_cmdliner_error r))
 
-let compact unsafe_buffering filename =
+let compact common_options_t unsafe_buffering filename =
+  handle_common common_options_t;
   let block =
      if unsafe_buffering
      then (module UnsafeBlock: BLOCK)

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -200,6 +200,17 @@ let unsafe_buffering =
   let doc = Printf.sprintf "Run faster by caching writes in memory. A failure in the middle could corrupt the file." in
   Arg.(value & flag & info [ "unsafe-buffering" ] ~doc)
 
+let discard_cmd =
+  let doc = "Scan for zeroes and discard them" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Iterate over all allocated blocks in the image, and if a block only
+        contains zeroes, then invoke discard (aka TRIM or UNMAP) on it. This
+        helps shrink the blocks in the file.";
+  ] @ help in
+  Term.(ret(pure Impl.discard $ unsafe_buffering $ filename)),
+  Term.info "discard" ~sdocs:_common_options ~doc ~man
+
 let repair_cmd =
   let doc = "Regenerate the refcount table in an image" in
   let man = [
@@ -259,7 +270,7 @@ let default_cmd =
   Term.info "qcow-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
 
 let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
-  write_cmd; read_cmd; mapped_cmd; resize_cmd]
+  write_cmd; read_cmd; mapped_cmd; resize_cmd; discard_cmd]
 
 let _ =
   Logs.set_reporter (Logs_fmt.reporter ());

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -211,6 +211,16 @@ let discard_cmd =
   Term.(ret(pure Impl.discard $ unsafe_buffering $ filename)),
   Term.info "discard" ~sdocs:_common_options ~doc ~man
 
+let compact_cmd =
+  let doc = "Compact the file" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Iterate over all the unallocated blocks ('holes') in the file created
+        by discard and move live data into them to shrink the file.";
+  ] @ help in
+  Term.(ret(pure Impl.compact $ unsafe_buffering $ filename)),
+  Term.info "compact" ~sdocs:_common_options ~doc ~man
+
 let repair_cmd =
   let doc = "Regenerate the refcount table in an image" in
   let man = [
@@ -270,7 +280,7 @@ let default_cmd =
   Term.info "qcow-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
 
 let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
-  write_cmd; read_cmd; mapped_cmd; resize_cmd; discard_cmd]
+  write_cmd; read_cmd; mapped_cmd; resize_cmd; discard_cmd; compact_cmd]
 
 let _ =
   Logs.set_reporter (Logs_fmt.reporter ());

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -39,7 +39,10 @@ let common_options_t =
   let debug =
     let doc = "Give only debug output." in
     Arg.(value & flag & info ["debug"] ~docs ~doc) in
-  Term.(pure Common.make $ debug)
+  let progress =
+    let doc = "Display a progress bar." in
+    Arg.(value & flag & info ["progress"] ~docs ~doc) in
+  Term.(pure Common.make $ debug $ progress)
 
 let filename =
   let doc = Printf.sprintf "Path to the qcow2 file." in

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -218,7 +218,7 @@ let compact_cmd =
     `P "Iterate over all the unallocated blocks ('holes') in the file created
         by discard and move live data into them to shrink the file.";
   ] @ help in
-  Term.(ret(pure Impl.compact $ unsafe_buffering $ filename)),
+  Term.(ret(pure Impl.compact $ common_options_t $ unsafe_buffering $ filename)),
   Term.info "compact" ~sdocs:_common_options ~doc ~man
 
 let repair_cmd =

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -744,6 +744,12 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
       }
     end
 
+  let discard t ~sector ~n () =
+    Log.debug (fun f -> f "Qcow.discard %Ld, %Ld: not currently implemented" sector n);
+    (* discard is a hint, it does not have to have any effect. Therefore it is
+       not an error that it is unimplemented. *)
+    Lwt.return (`Ok ())
+
   let create base ~size ?(lazy_refcounts=true) () =
     let version = `Three in
     let backing_file_offset = 0L in

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -634,6 +634,101 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
         Lwt.return (`Ok ())
       ) (chop_into_aligned cluster_size byte bufs)
 
+  let compact t =
+    (* Iterate over the all clusters referenced from all the tables in the file
+       and (a) construct a set of free clusters; and (b) construct a map of
+       physical cluster back to virtual. The free set will show us the holes,
+       and the map will tell us where to get the data from to fill the holes in
+       with. *)
+    let module Int64Set = Qcow_diet.Make(Int64) in
+    let refcount_start_cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits (Physical.make t.h.Header.refcount_table_offset) in
+    let int64s_per_cluster = 1L <| (Int32.to_int t.h.Header.cluster_bits - 3) in
+    let l1_table_start_cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits (Physical.make t.h.Header.l1_table_offset) in
+    let l1_table_clusters = Int64.(div (round_up (of_int32 t.h.Header.l1_size) int64s_per_cluster) int64s_per_cluster) in
+    (* Subtract the fixed structures at the beginning of the file *)
+    let whole_file = Int64Set.(add (0L, Int64.pred t.next_cluster) empty) in
+    let free = Int64Set.(
+      remove (l1_table_start_cluster, Int64.add l1_table_start_cluster l1_table_clusters)
+      @@ remove (refcount_start_cluster, Int64.add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters))
+      @@ remove (0L, 0L)
+      whole_file
+    ) in
+
+    (* mark a virtual -> physical mapping as in use *)
+    let mark free _virt phys =
+      let cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits phys in
+      if Physical.to_bytes phys = 0L
+      then free
+      else Int64Set.remove (cluster, cluster) free in
+
+    (* scan the refcount table *)
+    let rec loop free i =
+      if i >= Int64.of_int32 t.h.Header.refcount_table_clusters
+      then Lwt.return (`Ok free)
+      else begin
+        ClusterCache.read t.cache Int64.(add refcount_start_cluster i)
+          (fun buf ->
+            let rec loop free i =
+              if i >= (Cstruct.len buf)
+              then Lwt.return (`Ok free)
+              else begin
+                let addr = Physical.make (Cstruct.BE.get_uint64 buf i) in
+                let free = mark free None addr in
+                loop free (8 + i)
+              end in
+            loop free 0
+          )
+        >>*= fun free ->
+        loop free (Int64.succ i)
+      end in
+    loop free 0L
+    >>*= fun free ->
+
+    (* scan the L1 and L2 tables, marking the L2 and data clusters *)
+    let rec l1_iter free i =
+      if i >= l1_table_clusters
+      then Lwt.return (`Ok free)
+      else begin
+        ClusterCache.read t.cache Int64.(add l1_table_start_cluster i)
+          (fun l1 ->
+            Lwt.return (`Ok l1)
+          )
+        >>*= fun l1 ->
+        let rec l2_iter free i =
+          if i >= (Cstruct.len l1)
+          then Lwt.return (`Ok free)
+          else begin
+            let addr = Physical.make (Cstruct.BE.get_uint64 l1 i) in
+            let cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits addr in
+            let free = mark free None addr in
+            ClusterCache.read t.cache cluster
+              (fun l2 ->
+                Lwt.return (`Ok l2)
+              )
+            >>*= fun l2 ->
+            let rec data_iter free i =
+              if i >= (Cstruct.len l2)
+              then Lwt.return (`Ok free)
+              else begin
+                let addr = Physical.make (Cstruct.BE.get_uint64 l2 i) in
+                let cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits addr in
+                let free = mark free None addr in
+                data_iter free (8 + i)
+              end in
+            data_iter free 0
+            >>*= fun free ->
+            l2_iter free (8 + i)
+          end in
+        l2_iter free 0
+        >>*= fun free ->
+        l1_iter free (Int64.succ i)
+      end in
+    l1_iter free 0L
+    >>*= fun _free ->
+
+    Lwt.return (`Ok ())
+
+
   let seek_mapped t from =
     let bytes = Int64.(mul from (of_int t.sector_size)) in
     let addr = Qcow_virtual.make ~cluster_bits:t.cluster_bits bytes in

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -38,7 +38,16 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
       smaller than the old size as this would cause data loss, unless the argument
       [?ignore_data_loss] is set to true. *)
 
-  val compact: t -> ?progress_cb:(percent:int -> unit) -> unit -> [ `Ok of unit | `Error of error ] io
+  type compact_result = {
+      copied:       int64; (** number of sectors copied *)
+      refs_updated: int64; (** number of cluster references updated *)
+      old_size:     int64; (** previous size in sectors *)
+      new_size:     int64; (** new size in sectors *)
+  }
+  (** Summary of the compaction run *)
+
+  val compact: t -> ?progress_cb:(percent:int -> unit) -> unit ->
+    [ `Ok of compact_result | `Error of error ] io
   (** [compact t ()] scans the disk for unused space and attempts to fill it
       and shrink the file. This is useful if the underlying block device doesn't
       support discard and we must emulate it. *)

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -38,6 +38,11 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
       smaller than the old size as this would cause data loss, unless the argument
       [?ignore_data_loss] is set to true. *)
 
+  val discard: t -> sector:int64 -> n:int64 -> unit -> [ `Ok of unit | `Error of error ] io
+  (** [discard sector n] signals that the [n] sectors starting at [sector]
+      are no longer needed and the contents may be discarded. Note the contents
+      may not actually be deleted: this is not a "secure erase". *)
+
   val seek_unmapped: t -> int64 -> [ `Ok of int64 | `Error of error ] io
   (** [seek_unmapped t start] returns the offset of the next "hole": a region
       of the device which is guaranteed to be full of zeroes (typically

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -38,6 +38,11 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
       smaller than the old size as this would cause data loss, unless the argument
       [?ignore_data_loss] is set to true. *)
 
+  val compact: t -> [ `Ok of unit | `Error of error ] io
+  (** [compact t ()] scans the disk for unused space and attempts to fill it
+      and shrink the file. This is useful if the underlying block device doesn't
+      support discard and we must emulate it. *)
+
   val discard: t -> sector:int64 -> n:int64 -> unit -> [ `Ok of unit | `Error of error ] io
   (** [discard sector n] signals that the [n] sectors starting at [sector]
       are no longer needed and the contents may be discarded. Note the contents

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -38,7 +38,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
       smaller than the old size as this would cause data loss, unless the argument
       [?ignore_data_loss] is set to true. *)
 
-  val compact: t -> [ `Ok of unit | `Error of error ] io
+  val compact: t -> ?progress_cb:(percent:int -> unit) -> unit -> [ `Ok of unit | `Error of error ] io
   (** [compact t ()] scans the disk for unused space and attempts to fill it
       and shrink the file. This is useful if the underlying block device doesn't
       support discard and we must emulate it. *)

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -299,10 +299,21 @@ module Test = struct
     let open IntDiet in
     assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
 
+  let test_remove_1 () =
+    let open IntDiet in
+    assert (elements @@ remove (6, 7) @@ add (7, 8) empty = [ 8 ])
+
+  let test_remove_2 () =
+    let open IntDiet in
+    assert (elements @@ diff (add (9, 9) @@ add (5, 7) empty) (add (7, 9) empty) = [5; 6])
+
   let all = [
     "adding an element to the right", test_add_1;
+    "removing an element on the left", test_remove_1;
+    "removing an elements from two intervals", test_remove_2;
     "adding and removing elements acts like a Set", test_adds;
     "union", test_operator IntSet.union IntDiet.union;
+    "diff", test_operator IntSet.diff IntDiet.diff;
   ]
 
 end

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -109,6 +109,11 @@ module Make(Elt: ELT) = struct
       (* or search left or search right *)
       (if elt < n.x then mem elt n.l else mem elt n.r)
 
+  let rec min_elt = function
+    | Empty  -> raise Not_found
+    | Node { x; y; l = Empty; _ } -> x, y
+    | Node { l; _ } -> min_elt l
+
   let rec max_elt = function
     | Empty -> raise Not_found
     | Node { x; y; r = Empty; _ } -> x, y

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -170,11 +170,11 @@ module Make(Elt: ELT) = struct
       let r = add (x, y) n.r in
       Node (addR { n with r })
     (* overlap on the left only *)
-    | Node n when x < n.x && y < n.y ->
+    | Node n when x < n.x && y <= n.y ->
       let l = add (x, pred n.x) n.l in
       Node (addL { n with l })
     (* overlap on the right only *)
-    | Node n when y > n.y && x > n.x ->
+    | Node n when y > n.y && x >= n.x ->
       let r = add (succ n.y, y) n.r in
       Node (addR { n with r })
     (* overlap on both sides *)

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -314,6 +314,7 @@ module Test = struct
     "adding and removing elements acts like a Set", test_adds;
     "union", test_operator IntSet.union IntDiet.union;
     "diff", test_operator IntSet.diff IntDiet.diff;
+    "intersection", test_operator IntSet.inter IntDiet.inter;
   ]
 
 end

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -202,10 +202,10 @@ module Make(Elt: ELT) = struct
     | Node n when n.y < x -> Node { n with r = remove (x, y) n.r }
     (* overlap on the left only *)
     | Node n when x < n.x && y < n.y ->
-      remove (x, n.x) (Node { n with x = y })
+      remove (x, pred n.x) (Node { n with x = succ y })
     (* overlap on the right only *)
     | Node n when y > n.y && x > n.x ->
-      remove (n.y, x) (Node { n with y = x })
+      remove (succ n.y, y) (Node { n with y = pred x })
     (* overlap on both sides *)
     | Node n when x <= n.x && y >= n.y ->
       let l = remove (x, n.x) n.l in

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -279,6 +279,30 @@ module Test = struct
       check_equals set diet;
     done
 
-  let all () = test_adds ()
+  let test_operator set_op diet_op () =
+    for i = 1 to 1000 do
+      let set1, diet1 = make_random 1000 1000 in
+      let set2, diet2 = make_random 1000 1000 in
+      check_equals set1 diet1;
+      check_equals set2 diet2;
+      let set3 = set_op set1 set2 in
+      let diet3 = diet_op diet1 diet2 in
+      (*
+      Printf.fprintf stderr "diet1 = %s\n" (IntDiet.to_string_internal diet1);
+      Printf.fprintf stderr "diet3 = %s\n" (IntDiet.to_string_internal diet2);
+      Printf.fprintf stderr "diet2 = %s\n" (IntDiet.to_string_internal diet3);
+      *)
+      check_equals set3 diet3
+    done
+
+  let test_add_1 () =
+    let open IntDiet in
+    assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
+
+  let all = [
+    "adding an element to the right", test_add_1;
+    "adding and removing elements acts like a Set", test_adds;
+    "union", test_operator IntSet.union IntDiet.union;
+  ]
 
 end

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -221,7 +221,7 @@ module Make(Elt: ELT) = struct
 
   let diff a b = fold remove b a
 
-  let inter a b = union (diff a b) (diff b a)
+  let inter a b = diff a (diff a b)
 
 end
 

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -1,0 +1,284 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+(* #require "ppx_sexp_conv";; *)
+open Sexplib.Std
+
+module type ELT = sig
+  type t [@@deriving sexp]
+  val compare: t -> t -> int
+  val pred: t -> t
+  val succ: t -> t
+end
+
+exception Interval_pairs_should_be_ordered of string
+exception Intervals_should_not_overlap of string
+
+let _ =
+  Printexc.register_printer
+    (function
+      | Interval_pairs_should_be_ordered txt ->
+        Some ("Pairs within each interval should be ordered: " ^ txt)
+      | Intervals_should_not_overlap txt ->
+        Some ("Intervals should be ordered without overlap: " ^ txt)
+      | _ ->
+        None
+    )
+
+module Make(Elt: ELT) = struct
+  type elt = Elt.t [@@deriving sexp]
+
+  type interval = elt * elt
+
+  module Interval = struct
+    let make x y =
+      if x > y then invalid_arg "Interval.make";
+      x, y
+  end
+
+  let ( >  ) x y = Elt.compare x y > 0
+  let ( >= ) x y = Elt.compare x y >= 0
+  let ( <  ) x y = Elt.compare x y < 0
+  let ( <= ) x y = Elt.compare x y <= 0
+  let eq     x y = Elt.compare x y = 0
+  let succ, pred = Elt.succ, Elt.pred
+
+  type t =
+    | Empty
+    | Node: node -> t
+  and node = { x: elt; y: elt; l: t; r: t }
+  [@@deriving sexp]
+
+  let to_string_internal t = Sexplib.Sexp.to_string_hum @@ sexp_of_t t
+
+  module Invariant = struct
+
+    (* The pairs (x, y) in each interval are ordered such that x <= y *)
+    let rec ordered t = match t with
+      | Empty -> ()
+      | Node { x; y; l; r } ->
+        if x > y then raise (Interval_pairs_should_be_ordered (to_string_internal t));
+        ordered l;
+        ordered r
+
+    (* The intervals don't overlap *)
+    let rec no_overlap t = match t with
+      | Empty -> ()
+      | Node { x; y; l; r } ->
+        begin match l with
+          | Empty -> ()
+          | Node left -> if left.y >= x then raise (Intervals_should_not_overlap (to_string_internal t))
+        end;
+        begin match r with
+          | Empty -> ()
+          | Node right -> if right.x <= y then raise (Intervals_should_not_overlap (to_string_internal t))
+        end;
+        no_overlap l;
+        no_overlap r
+
+    let check t =
+      ordered t;
+      no_overlap t
+  end
+
+  let empty = Empty
+
+  let is_empty = function
+    | Empty -> true
+    | _ -> false
+
+  let rec mem elt = function
+    | Empty -> false
+    | Node n ->
+      (* consider this interval *)
+      (elt >= n.x && elt <= n.y)
+      ||
+      (* or search left or search right *)
+      (if elt < n.x then mem elt n.l else mem elt n.r)
+
+  (* fold over the maximal contiguous intervals *)
+  let rec fold f t acc = match t with
+    | Empty -> acc
+    | Node n ->
+      let acc = fold f n.l acc in
+      let acc = f (n.x, n.y) acc in
+      fold f n.r acc
+
+  (* fold over individual elements *)
+  let fold_individual f t acc =
+    let range (from, upto) acc =
+      let rec loop acc x =
+        if eq x (succ upto) then acc else loop (f x acc) (succ x) in
+      loop acc from in
+    fold range t acc
+
+  let elements t = fold_individual (fun x acc -> x :: acc) t [] |> List.rev
+
+  (* return (x, y, l) where (x, y) is the maximal interval and [l] is
+     the rest of the tree on the left (whose intervals are all smaller). *)
+  let rec splitMax = function
+    | { x; y; l; r = Empty } -> x, y, l
+    | { r = Node r; _ } as n ->
+      let u, v, r' = splitMax r in
+      u, v, Node { n with r = r' }
+
+  (* return (x, y, r) where (x, y) is the minimal interval and [r] is
+     the rest of the tree on the right (whose intervals are all larger) *)
+  let rec splitMin = function
+    | { x; y; l = Empty; r } -> x, y, r
+    | { l = Node l; _ } as n ->
+      let u, v, l' = splitMin l in
+      u, v, Node { n with l = l' }
+
+  let addL = function
+    | { l = Empty; _ } as n -> n
+    | { l = Node l; _ } as n ->
+      (* we might have to merge the new element with the maximal interval from
+         the left *)
+      let x', y', l' = splitMax l in
+      if eq (succ y') n.x then { n with x = x'; l = l' } else n
+
+  let addR = function
+    | { r = Empty; _ } as n -> n
+    | { r = Node r; _ } as n ->
+      (* we might have to merge the new element with the minimal interval on
+         the right *)
+      let x', y', r' = splitMin r in
+      if eq (succ n.y) x' then { n with y = y'; r = r' } else n
+
+  let rec add (x, y) t = match t with
+    | Empty -> Node { x; y; l = Empty; r = Empty }
+    (* completely to the left *)
+    | Node n when y < n.x ->
+      let l = add (x, y) n.l in
+      Node (addL { n with l })
+    (* completely to the right *)
+    | Node n when n.y < x ->
+      let r = add (x, y) n.r in
+      Node (addR { n with r })
+    (* overlap on the left only *)
+    | Node n when x < n.x && y < n.y ->
+      let l = add (x, pred n.x) n.l in
+      Node (addL { n with l })
+    (* overlap on the right only *)
+    | Node n when y > n.y && x > n.x ->
+      let r = add (succ n.y, y) n.r in
+      Node (addR { n with r })
+    (* overlap on both sides *)
+    | Node n when x < n.x && y > n.y ->
+      let l = add (x, pred n.x) n.l in
+      let r = add (succ n.y, y) n.r in
+      Node (addL { (addR { n with r }) with l })
+    (* completely within *)
+    | Node n -> Node n
+
+  let union = fold add
+
+  let merge l r = match l, r with
+    | l, Empty -> l
+    | Empty, r -> r
+    | Node l, r ->
+      let x, y, l' = splitMax l in
+      Node { x; y; l = l'; r }
+
+  let rec remove (x, y) t = match t with
+    | Empty -> Empty
+    (* completely to the left *)
+    | Node n when y < n.x -> Node { n with l = remove (x, y) n.l }
+    (* completely to the right *)
+    | Node n when n.y < x -> Node { n with r = remove (x, y) n.r }
+    (* overlap on the left only *)
+    | Node n when x < n.x && y < n.y ->
+      remove (x, n.x) (Node { n with x = y })
+    (* overlap on the right only *)
+    | Node n when y > n.y && x > n.x ->
+      remove (n.y, x) (Node { n with y = x })
+    (* overlap on both sides *)
+    | Node n when x <= n.x && y >= n.y ->
+      let l = remove (x, n.x) n.l in
+      let r = remove (n.y, y) n.r in
+      merge l r
+    (* completely within *)
+    | Node n when eq y n.y -> Node { n with y = pred x }
+    | Node n when eq x n.x -> Node { n with x = succ y }
+    | Node n ->
+      assert (n.x <= pred x);
+      assert (succ y <= n.y);
+      Node { n with y = (pred x); r = Node { n with x = succ y; l = Empty } }
+
+  let diff a b = fold remove b a
+
+  let inter a b = union (diff a b) (diff b a)
+
+end
+
+module Int = struct
+  type t = int [@@deriving sexp]
+  let compare (x: t) (y: t) = Pervasives.compare x y
+  let succ x = x + 1
+  let pred x = x - 1
+end
+module IntDiet = Make(Int)
+module IntSet = Set.Make(Int)
+
+module Test = struct
+
+  let make_random n m =
+    let rec loop set diet = function
+      | 0 -> set, diet
+      | m ->
+        let r = Random.int n in
+        let set, diet =
+          if Random.bool ()
+          then IntSet.add r set, IntDiet.add (IntDiet.Interval.make r r) diet
+          else IntSet.remove r set, IntDiet.remove (IntDiet.Interval.make r r) diet in
+        loop set diet (m - 1) in
+    loop IntSet.empty IntDiet.empty m
+
+  let set_to_string set =
+    String.concat "; " @@ List.map string_of_int @@ IntSet.elements set
+  let diet_to_string diet =
+    String.concat "; " @@ List.map string_of_int @@ IntDiet.elements diet
+
+  let check_equals set diet =
+    let set' = IntSet.elements set in
+    let diet' = IntDiet.elements diet in
+    if set' <> diet' then begin
+      (*
+      Printf.fprintf stderr "Set contains: [ %s ]\n" @@ set_to_string set;
+      Printf.fprintf stderr "Diet contains: [ %s ]\n" @@ diet_to_string diet;
+      *)
+      failwith "check_equals"
+    end
+
+  let test_adds () =
+    for i = 1 to 1000 do
+      let set, diet = make_random 1000 1000 in
+      begin
+        try
+          IntDiet.Invariant.check diet
+        with e ->
+          (*
+          Printf.fprintf stderr "Diet contains: [ %s ]\n" @@ IntDiet.to_string_internal diet;
+          *)
+          raise e
+      end;
+      check_equals set diet;
+    done
+
+  let all () = test_adds ()
+
+end

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -109,6 +109,11 @@ module Make(Elt: ELT) = struct
       (* or search left or search right *)
       (if elt < n.x then mem elt n.l else mem elt n.r)
 
+  let rec max_elt = function
+    | Empty -> raise Not_found
+    | Node { x; y; r = Empty; _ } -> x, y
+    | Node { r; _ } -> max_elt r
+
   (* fold over the maximal contiguous intervals *)
   let rec fold f t acc = match t with
     | Empty -> acc

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -66,6 +66,10 @@ module Make(Elt: ELT): sig
   val remove: interval -> t -> t
   (** [remove interval t] returns the set consisting of [t] minus [interval] *)
 
+  val min_elt: t -> interval
+  (** [min_elt t] returns the smallest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
   val max_elt: t -> interval
   (** [max_elt t] returns the largest (in terms of the ordering) interval in
       [t], or raises [Not_found] if the set is empty. *)

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -77,5 +77,5 @@ module Make(Elt: ELT): sig
 end
 
 module Test: sig
-  val all: unit -> unit
+  val all: (string * (unit -> unit)) list
 end

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -66,6 +66,10 @@ module Make(Elt: ELT): sig
   val remove: interval -> t -> t
   (** [remove interval t] returns the set consisting of [t] minus [interval] *)
 
+  val max_elt: t -> interval
+  (** [max_elt t] returns the largest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
   val union: t -> t -> t
   (** set union *)
 

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -1,0 +1,81 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module type ELT = sig
+  type t [@@deriving sexp]
+  (** The type of the set elements. *)
+
+  include Set.OrderedType with type t := t
+
+  val pred: t -> t
+  (** Predecessor of an element *)
+
+  val succ: t -> t
+  (** Successor of an element *)
+end
+
+module Make(Elt: ELT): sig
+  (** A discrete interval encoding tree: a set of elements optimised for cases
+      where large numbers of contiguous elements are in the set. *)
+
+  type elt = Elt.t [@@deriving sexp]
+  (** The type of the set elements *)
+
+  type interval = elt * elt
+  (** An interval: a range (x, y) of set values where all the elements from
+      x to y inclusive are in the set *)
+
+  module Interval: sig
+    val make: elt -> elt -> interval
+    (** [make first last] construct an interval describing all the elements from
+        [first] to [last] inclusive. *)
+  end
+
+  type t [@@deriving sexp]
+  (** The type of sets *)
+
+  val empty: t
+  (** The empty set *)
+
+  val is_empty: t -> bool
+  (** Test whether a set is empty or not *)
+
+  val mem: elt -> t -> bool
+  (** [mem elt t] tests whether [elt] is in set [t] *)
+
+  val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
+  (** [fold f t acc] folds [f] across all the intervals in [t] *)
+
+  val add: interval -> t -> t
+  (** [add interval t] returns the set consisting of [t] plus [interval] *)
+
+  val remove: interval -> t -> t
+  (** [remove interval t] returns the set consisting of [t] minus [interval] *)
+
+  val union: t -> t -> t
+  (** set union *)
+
+  val diff: t -> t -> t
+  (** set difference *)
+
+  val inter: t -> t -> t
+  (** set intersection *)
+end
+
+module Test: sig
+  val all: unit -> unit
+end

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -1,0 +1,132 @@
+(*
+ * Copyright (C) 2013 Citrix Inc
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+module FromBlock = Error.FromBlock
+module FromResult = Error.FromResult
+
+open Sexplib.Std
+open Qcow
+open Lwt
+open OUnit
+open Utils
+open Sizes
+
+module Block = UnsafeBlock
+
+(* Create a file which can store [nr_clusters], then randomly write and discard,
+   checking with read whether the expected data is in each cluster. By convention
+   we write the cluster index into each cluster so we can detect if they
+   permute or alias. *)
+let random_write_discard_compact nr_clusters =
+  (* create a large disk *)
+  let open Lwt.Infix in
+  let module B = Qcow.Make(Block) in
+  let cluster_bits = 16 in (* FIXME: avoid hardcoding this *)
+  let cluster_size = 1 lsl cluster_bits in
+  let size = Int64.(mul nr_clusters (of_int cluster_size)) in
+  let path = Filename.concat test_dir (Int64.to_string size) ^ ".compact" in
+  let t =
+    truncate path
+    >>= fun () ->
+    let open FromBlock in
+    Block.connect path
+    >>= fun block ->
+    B.create block ~size ()
+    >>= fun qcow ->
+    let h = B.header qcow in
+    let open Lwt.Infix in
+    B.get_info qcow
+    >>= fun info ->
+    let sectors_per_cluster = cluster_size / info.B.sector_size in
+
+    (* add to this set on write, remove on discard *)
+    let module ClusterSet = Qcow_diet.Make(Qcow_types.Int64) in
+    let written = ref ClusterSet.empty in
+
+    let make_cluster idx =
+      let cluster = malloc cluster_size in
+      for i = 0 to cluster_size / 8 - 1 do
+        Cstruct.BE.set_uint64 cluster (i * 8) idx
+      done;
+      cluster in
+    let write_cluster idx =
+      let cluster = make_cluster idx in
+      B.write qcow Int64.(mul idx (of_int sectors_per_cluster)) [ cluster ]
+      >>= function
+      | `Error _ -> failwith "write"
+      | `Ok () ->
+        written := ClusterSet.add (idx, idx) !written;
+        Lwt.return_unit in
+    let discard_cluster idx =
+      B.discard qcow ~sector:Int64.(mul idx (of_int sectors_per_cluster)) ~n:(Int64.of_int sectors_per_cluster) ()
+      >>= function
+      | `Error _ -> failwith "discard"
+      | `Ok () ->
+        written := ClusterSet.remove (idx, idx) !written;
+        Lwt.return_unit in
+    let read_cluster idx =
+      let cluster = malloc cluster_size in
+      B.read qcow Int64.(mul idx (of_int sectors_per_cluster)) [ cluster ]
+      >>= function
+      | `Error _ -> failwith "read"
+      | `Ok () ->
+        Lwt.return cluster in
+    let check_contents cluster expected =
+      for i = 0 to cluster_size / 8 - 1 do
+        let actual = Cstruct.BE.get_uint64 cluster (i * 8) in
+        if actual <> expected
+        then failwith (Printf.sprintf "contents of cluster incorrect: expected %Ld but actual %Ld" expected actual)
+      done in
+    let check_all_clusters () =
+      let rec loop n =
+        if n = nr_clusters then Lwt.return_unit else begin
+          read_cluster n
+          >>= fun buf ->
+          let expected = if ClusterSet.mem n !written then n else 0L in
+          check_contents buf expected;
+          loop (Int64.succ n)
+        end in
+      loop 0L in
+    Random.init 0;
+    let rec loop () =
+      let r = Random.int 21 in
+      (* A random action: mostly a write or a discard, occasionally a compact *)
+      ( if 0 <= r && r < 10 then begin
+          let idx = Random.int64 nr_clusters in
+          Printf.fprintf stderr "write %Ld\n%!" idx;
+          write_cluster idx
+        end else if 10 <= r && r < 20 then begin
+          let idx = Random.int64 nr_clusters in
+          Printf.fprintf stderr "discard %Ld\n%!" idx;
+          discard_cluster idx
+        end else begin
+          Printf.fprintf stderr "compact\n%!";
+          B.compact qcow ()
+          >>= function
+          | `Error _ -> failwith "compact"
+          | `Ok _report -> Lwt.return_unit
+        end )
+      >>= fun () ->
+      check_all_clusters ()
+      >>= fun () ->
+      Printf.printf ".%!";
+      loop () in
+    loop () in
+  or_failwith @@ Lwt_main.run t
+
+let _ =
+  random_write_discard_compact 128L;
+  (* If no error, delete the directory *)
+  ignore(run "rm" [ "-rf"; test_dir ])

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -634,7 +634,7 @@ let create_write_discard_compact () =
     (* compact *)
     let open FromBlock in
     B.compact qcow ()
-    >>= fun () ->
+    >>= fun _report ->
     let open Lwt.Infix in
     (* check all the values are as expected *)
     Lwt_list.iter_s

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -524,6 +524,7 @@ let _ =
       (fun (label, start, length) -> label >:: write_read_native sector_size size_sectors (start, Int64.to_int length))
       (interesting_ranges sector_size size_sectors cluster_bits) in
   let suite = "qcow2" >::: [
+      "DIETs" >:: Qcow_diet.Test.all;
       "check we can fill the disk" >:: check_full_disk;
       "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
       "create 1K" >:: create_1K;

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -523,14 +523,14 @@ let _ =
   let interesting_native_reads = List.map
       (fun (label, start, length) -> label >:: write_read_native sector_size size_sectors (start, Int64.to_int length))
       (interesting_ranges sector_size size_sectors cluster_bits) in
-  let suite = "qcow2" >::: [
-      "DIETs" >:: Qcow_diet.Test.all;
+  let diet_tests = List.map (fun (name, fn) -> name >:: fn) Qcow_diet.Test.all in
+  let suite = "qcow2" >::: (diet_tests @ [
       "check we can fill the disk" >:: check_full_disk;
       "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
       "create 1K" >:: create_1K;
       "create 1M" >:: create_1M;
       "create 1P" >:: create_1P;
-    ] @ interesting_native_reads @ interesting_qemu_reads @ qemu_img_suite @ qcow_tool_suite in
+    ] @ interesting_native_reads @ interesting_qemu_reads @ qemu_img_suite @ qcow_tool_suite) in
   OUnit2.run_test_tt_main (ounit2_of_ounit1 suite);
   (* If no error, delete the directory *)
   ignore(run "rm" [ "-rf"; test_dir ])

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -23,6 +23,13 @@ open OUnit
 open Utils
 open Sizes
 
+(* No need for data integrity during tests *)
+module UnsafeBlock = struct
+  include Block
+  let flush _ = Lwt.return (`Ok ())
+end
+module Block = UnsafeBlock
+
 let truncate path =
   Lwt_unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC ] 0o0644
   >>= fun fd ->


### PR DESCRIPTION
This PR adds support for a `discard` operation which marks a range of sectors as empty. The implementation guarantees "Read Zero After TRIM" semantics.

Space is not reclaimed immediately (yet), instead a special `compact` operation scans across all the metadata and shuffles blocks from the end of the file into holes near the start and updates any references to match. This should be run offline periodically and will truncate the file to make it smaller.

Two new CLI sub-commands have been added
- `discard`: scans the file for zeroes and calls `discard` on the blocks
- `compact`: runs the compactor and shrinks the file

For example

```
$ qcow-tool compact Docker.qcow2
I couldn't make the file any smaller. Consider running `discard`.
$ qcow-tool discard Docker.qcow2
$ qcow-tool compact Docker.qcow2
The file is now 3257 MiB smaller.
```