### PR TITLE
Add more sanity checks

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -201,12 +201,13 @@ let check filename =
       >>= function
       | `Error _ -> failwith (Printf.sprintf "Failed to read qcow formatted data on %s" filename)
       | `Ok x ->
-        Mirage_block.fold_s ~f:(fun acc ofs buf ->
-          return ()
-        ) () (module B) x
+        B.check x
         >>= function
-        | `Error (`Msg m) -> failwith m
-        | `Ok () ->
+        | `Error _ -> failwith (Printf.sprintf "Qcow consistency check failed on %s" filename)
+        | `Ok x ->
+          Printf.printf "Qcow file seems intact.\n";
+          Printf.printf "Total free blocks: %Ld\n" x.B.free;
+          Printf.printf "Total used blocks: %Ld\n" x.B.used;
           return (`Ok ()) in
   Lwt_main.run t
 

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -98,6 +98,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
   (** [rebuild_refcount_table t] rebuilds the refcount table from scratch.
       Normally we won't update the refcount table live, for performance. *)
 
+  type check_result = {
+    free: int64; (** unused sectors *)
+    used: int64; (** used sectors *)
+  }
+
+  val check: t -> [ `Ok of check_result | `Error of error ] io
+  (** [check t] performs sanity checks of the file, looking for errors *)
+
   val header: t -> Header.t
   (** Return a snapshot of the current header *)
 

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -47,6 +47,8 @@ module Make(Elt: ELT) = struct
     let make x y =
       if x > y then invalid_arg "Interval.make";
       x, y
+    let x = fst
+    let y = snd
   end
 
   let ( >  ) x y = Elt.compare x y > 0

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -35,7 +35,7 @@ module Make(Elt: ELT): sig
   type elt = Elt.t [@@deriving sexp]
   (** The type of the set elements *)
 
-  type interval = elt * elt
+  type interval
   (** An interval: a range (x, y) of set values where all the elements from
       x to y inclusive are in the set *)
 
@@ -43,6 +43,12 @@ module Make(Elt: ELT): sig
     val make: elt -> elt -> interval
     (** [make first last] construct an interval describing all the elements from
         [first] to [last] inclusive. *)
+
+    val x: interval -> elt
+    (** the starting element of the interval *)
+
+    val y: interval -> elt
+    (** the ending element of the interval *)
   end
 
   type t [@@deriving sexp]


### PR DESCRIPTION
- make `interval` abstract so we can't skip checking the invariant
- check that all cluster references are within the file
- check that no cluster has two references