### PR TITLE
Decouple discard from compact

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -50,6 +50,11 @@ module Block = struct
   let connect path = connect path
 end
 
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep = Lwt_unix.sleep
+end
+
 module TracedBlock = struct
   include Block
 
@@ -139,7 +144,7 @@ let write filename sector data trace =
      then (module TracedBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let t =
     let open Lwt in
     BLOCK.connect filename
@@ -166,7 +171,7 @@ let read filename sector length trace =
      then (module TracedBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let t =
     let open Lwt in
     BLOCK.connect filename
@@ -190,7 +195,7 @@ let read filename sector length trace =
   Lwt_main.run t
 
 let check filename =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let open Lwt in
   let t =
     Block.connect filename
@@ -228,7 +233,7 @@ let discard unsafe_buffering filename =
      then (module UnsafeBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
   let t =
     BLOCK.connect filename
@@ -278,7 +283,7 @@ let compact common_options_t unsafe_buffering filename =
      then (module UnsafeBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
   let progress_cb = if common_options_t.progress then Some progress_cb else None in
   let t =
@@ -309,7 +314,7 @@ let repair unsafe_buffering filename =
      then (module UnsafeBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
   let t =
     BLOCK.connect filename
@@ -324,7 +329,7 @@ let repair unsafe_buffering filename =
   Lwt_main.run (t >>= fun r -> return (to_cmdliner_error r))
 
 let decode filename output =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let open Lwt in
   let t =
     Block.connect filename
@@ -355,7 +360,7 @@ let decode filename output =
   Lwt_main.run t
 
 let encode filename output =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let open Lwt in
   let t =
     Block.connect filename
@@ -391,7 +396,7 @@ let create size strict_refcounts trace filename =
      then (module TracedBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
   let t =
     Lwt_unix.openfile filename [ Lwt_unix.O_CREAT ] 0o0644
@@ -414,7 +419,7 @@ let resize trace filename new_size ignore_data_loss =
      then (module TracedBlock: BLOCK)
      else (module Block: BLOCK) in
   let module BLOCK = (val block: BLOCK) in
-  let module B = Qcow.Make(BLOCK) in
+  let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
   let t =
     BLOCK.connect filename
@@ -451,7 +456,7 @@ let is_zero buf =
   loop 0
 
 let mapped filename format ignore_zeroes =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let open Lwt in
   let t =
     Block.connect filename

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -33,7 +33,7 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(B: Qcow_s.RESIZABLE_BLOCK) = struct
+module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
 
   type 'a io = 'a Lwt.t
   type error = B.error

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -17,7 +17,7 @@
 module Error = Qcow_error
 module Header = Qcow_header
 
-module Make(B: Qcow_s.RESIZABLE_BLOCK) : sig
+module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) : sig
   include V1_LWT.BLOCK
 
   module Config: sig

--- a/lib/qcow.mllib
+++ b/lib/qcow.mllib
@@ -6,4 +6,5 @@ Qcow_physical
 Qcow_s
 Qcow_diet
 Qcow_rwlock
+Qcow_timer
 Qcow

--- a/lib/qcow.mllib
+++ b/lib/qcow.mllib
@@ -5,4 +5,5 @@ Qcow_virtual
 Qcow_physical
 Qcow_s
 Qcow_diet
+Qcow_rwlock
 Qcow

--- a/lib/qcow_rwlock.ml
+++ b/lib/qcow_rwlock.ml
@@ -1,0 +1,79 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+let src =
+  let src = Logs.Src.create "qcow" ~doc:"qcow2-formatted BLOCK device" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type t = {
+  mutable nr_readers: int;
+  mutable writer: bool;
+  m: Lwt_mutex.t;
+  c: unit Lwt_condition.t;
+}
+let make () =
+  let nr_readers = 0 in
+  let writer = false in
+  let m = Lwt_mutex.create () in
+  let c = Lwt_condition.create () in
+  { nr_readers; writer; m; c }
+let with_read_lock t f =
+  let open Lwt.Infix in
+  Lwt_mutex.with_lock t.m
+    (fun () ->
+      let rec wait () =
+        if t.writer then begin
+          Lwt_condition.wait t.c ~mutex:t.m
+          >>= fun () ->
+          wait ()
+        end else begin
+          t.nr_readers <- t.nr_readers + 1;
+          Lwt.return_unit
+        end in
+      wait ()
+    )
+  >>= fun () ->
+  Lwt.finalize f
+    (fun () ->
+      t.nr_readers <- t.nr_readers - 1;
+      Lwt_condition.signal t.c ();
+      Lwt.return_unit
+    )
+let with_write_lock t f =
+  let open Lwt.Infix in
+  Lwt_mutex.with_lock t.m
+    (fun () ->
+      let rec wait () =
+        if t.nr_readers > 0 || t.writer then begin
+          Lwt_condition.wait t.c ~mutex:t.m
+          >>= fun () ->
+          wait ()
+        end else begin
+          t.writer <- true;
+          Lwt.return_unit
+        end in
+      wait ()
+    )
+  >>= fun () ->
+  Lwt.finalize f
+    (fun () ->
+      t.writer <- false;
+      Lwt_condition.broadcast t.c ();
+      Lwt.return_unit
+    )

--- a/lib/qcow_rwlock.mli
+++ b/lib/qcow_rwlock.mli
@@ -1,0 +1,29 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t
+(** A lock which permits multiple concurrent threads to acquire it for reading
+    but demands exclusivity for writing *)
+
+val make: unit -> t
+(** Create a RW lock *)
+
+val with_read_lock: t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+(** [with_read_lock t f] executes [f ()] with the lock held for reading *)
+
+val with_write_lock: t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+(** [with_write_lock t f] executes [f ()] with the lock held for writing *)

--- a/lib/qcow_timer.ml
+++ b/lib/qcow_timer.ml
@@ -1,0 +1,84 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let src =
+  let src = Logs.Src.create "qcow" ~doc:"qcow2-formatted BLOCK device" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make(Time: V1_LWT.TIME) = struct
+
+  type t = {
+    description: string;
+    mutable timer: unit Lwt.t;
+    f: unit -> unit Lwt.t;
+    mutable task_running: bool;
+    mutable please_schedule_another: bool;
+  }
+
+  let make ~f ~description () =
+    let timer = Lwt.return_unit in
+    let task_running = false in
+    let please_schedule_another = false in
+    { description; timer; f; task_running; please_schedule_another }
+
+  let restart t ~duration_ms =
+    let open Lwt.Infix in
+    Lwt.cancel t.timer;
+    match t.task_running with
+    | true ->
+      t.please_schedule_another <- true
+    | false ->
+      let timer = Time.sleep (float_of_int duration_ms /. 1000.0) in
+      t.timer <- timer;
+      let rec loop () =
+        Lwt.catch
+          (fun () ->
+            timer
+            >>= fun () ->
+            t.task_running <- true;
+            Log.info (fun f -> f "running background %s" t.description);
+            Lwt.catch
+              (fun () ->
+                t.f ()
+                >>= fun () ->
+                Log.info (fun f -> f "background %s successful" t.description);
+                Lwt.return_unit
+              )
+              (fun e ->
+                Log.err (fun f -> f "background %s failed with: %s" t.description (Printexc.to_string e));
+                Lwt.return_unit
+              )
+            >>= fun () ->
+            Lwt.return_unit
+          ) (function
+            | Lwt.Canceled -> Lwt.return_unit
+            | e ->
+              Log.err (fun f -> f "background %s timer failed with: %s" t.description (Printexc.to_string e));
+              Lwt.return_unit
+          )
+        >>= fun () ->
+        t.task_running <- false;
+        if t.please_schedule_another then begin
+          t.please_schedule_another <- false;
+          loop ()
+        end else
+          Lwt.return_unit in
+      Lwt.async loop
+end

--- a/lib/qcow_timer.mli
+++ b/lib/qcow_timer.mli
@@ -1,0 +1,37 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module Make(Time: V1_LWT.TIME): sig
+
+  type t
+  (** A timer which runs a background task after a set duration. The timer can
+      be reset at any time. The timer guarantees to wait at least the set
+      duration before running the task again. *)
+
+  val make: f:(unit -> unit Lwt.t) -> description:string -> unit -> t
+  (** Create timer which is initially stopped. *)
+
+  val restart: t -> duration_ms:int -> unit
+  (** Restart the timer.
+
+      If the task is running now then another will be scheduled
+      to start [duration_ms] milliseconds after the running one has finished.
+
+      If no task is running then any existing scheduled task is removed and a
+      new one is scheduled for [duration_ms] from now.
+  *)
+end

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -34,7 +34,7 @@ let debug = ref false
 let random_write_discard_compact nr_clusters stop_after =
   (* create a large disk *)
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let cluster_bits = 16 in (* FIXME: avoid hardcoding this *)
   let cluster_size = 1 lsl cluster_bits in
   let size = Int64.(mul nr_clusters (of_int cluster_size)) in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -26,7 +26,7 @@ open Sizes
 module Block = UnsafeBlock
 
 let repair_refcounts path =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let t =
     let open FromBlock in
     Block.connect path
@@ -49,7 +49,7 @@ let repair_refcounts path =
    presumably for extension headers *)
 
 let read_write_header name size =
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let path = Filename.concat test_dir (Printf.sprintf "read_write_header.%s.%Ld" name size) in
 
   let t =
@@ -142,7 +142,7 @@ let rec fragment into remaining =
 
 let check_file_contents path id sector_size size_sectors (start, length) () =
   let module RawReader = Block in
-  let module Reader = Qcow.Make(RawReader) in
+  let module Reader = Qcow.Make(RawReader)(Time) in
   let sector = Int64.div start 512L in
   (* This is the range that we expect to see written *)
   let open FromBlock in
@@ -188,7 +188,7 @@ let check_file_contents path id sector_size size_sectors (start, length) () =
 
 let write_read_native sector_size size_sectors (start, length) () =
   let module RawWriter = Block in
-  let module Writer = Qcow.Make(RawWriter) in
+  let module Writer = Qcow.Make(RawWriter)(Time) in
   let path = Filename.concat test_dir (Printf.sprintf "write_read_native.%Ld.%Ld.%d" size_sectors start length) in
 
   let t =
@@ -224,7 +224,7 @@ let write_read_native sector_size size_sectors (start, length) () =
 
 let write_discard_read_native sector_size size_sectors (start, length) () =
   let module RawWriter = Block in
-  let module Writer = Qcow.Make(RawWriter) in
+  let module Writer = Qcow.Make(RawWriter)(Time) in
   let path = Filename.concat test_dir (Printf.sprintf "write_discard_read_native.%Ld.%Ld.%d" size_sectors start length) in
   let t =
     truncate path
@@ -296,7 +296,7 @@ let write_read_qemu sector_size size_sectors (start, length) () =
     or_failwith @@ Lwt_main.run t
 
 let check_refcount_table_allocation () =
-  let module B = Qcow.Make(Ramdisk) in
+  let module B = Qcow.Make(Ramdisk)(Time) in
   let t =
     Ramdisk.destroy ~name:"test";
     let open FromBlock in
@@ -318,7 +318,7 @@ let check_refcount_table_allocation () =
   or_failwith @@ Lwt_main.run t
 
 let check_full_disk () =
-  let module B = Qcow.Make(Ramdisk) in
+  let module B = Qcow.Make(Ramdisk)(Time) in
   let t =
     Ramdisk.destroy ~name:"test";
     let open FromBlock in
@@ -356,7 +356,7 @@ let virtual_sizes = [
 let check_file path size =
   let info = Qemu.Img.info path in
   assert_equal ~printer:Int64.to_string size info.Qemu.Img.virtual_size;
-  let module M = Qcow.Make(Block) in
+  let module M = Qcow.Make(Block)(Time) in
   repair_refcounts path
   >>= fun () ->
   Qemu.Img.check path;
@@ -406,7 +406,7 @@ let qemu_img_suite =
 
 let qcow_tool size =
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let path = Filename.concat test_dir (Int64.to_string size) in
 
   let t =
@@ -427,7 +427,7 @@ let qcow_tool size =
 
 let qcow_tool_resize ?ignore_data_loss size_from size_to =
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let path = Filename.concat test_dir (Int64.to_string size_from) in
 
   let t =
@@ -450,7 +450,7 @@ let qcow_tool_resize ?ignore_data_loss size_from size_to =
 
 let qcow_tool_bad_resize size_from size_to =
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let path = Filename.concat test_dir (Int64.to_string size_from) in
 
   let t =
@@ -475,7 +475,7 @@ let qcow_tool_bad_resize size_from size_to =
 
 let create_resize_equals_create size_from size_to =
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let path1 = Filename.concat test_dir (Int64.to_string size_from) in
   let path2 = path1 ^ ".resized" in
   let t =
@@ -516,7 +516,7 @@ let range from upto =
 let create_write_discard_all_compact clusters () =
   (* create a large disk *)
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let size = gib in
   let path = Filename.concat test_dir (Int64.to_string size) ^ ".compact" in
   let t =
@@ -564,7 +564,7 @@ let create_write_discard_all_compact clusters () =
 let create_write_discard_compact () =
   (* create a large disk *)
   let open Lwt.Infix in
-  let module B = Qcow.Make(Block) in
+  let module B = Qcow.Make(Block)(Time) in
   let size = gib in
   let path = Filename.concat test_dir (Int64.to_string size) ^ ".compact" in
   let t =

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -108,3 +108,8 @@ let test_dir =
 let malloc (length: int) =
   let npages = (length + 4095)/4096 in
   Cstruct.sub Io_page.(to_cstruct (get npages)) 0 length
+
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep = Lwt_unix.sleep
+end


### PR DESCRIPTION
Previously if we had a configured auto-compaction threshold then we would perform the compact synchronously in a discard. This meant that

- `discard` could block for a long time
- if discarding a lot, we could waste time shuffling blocks that we're about to delete

This PR (re-)starts a timer on every discard over the threshold and only triggers the compact if there have been no discards for 1s.

Note this functorises `Qcow` over `V1_LWT.TIME`