### PR TITLE
Interrupt the background compact, rather than block I/O

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -886,9 +886,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
                    block has been copied to. (Otherwise we may go to adjust the referring block
                    only to find it has also been moved) *)
                 compact_s
-                  (fun ({ src; dst; _ } as move) map (moves, _, substitutions) ->
+                  (fun ({ src; dst; _ } as move) new_map (moves, existing_map, substitutions) ->
                     if !cancel_requested
-                    then Lwt.return (`Ok (moves, map, substitutions))
+                    then Lwt.return (`Ok (moves, existing_map, substitutions))
                     else begin
                       Log.debug (fun f -> f "Copy cluster %Ld to %Ld" src dst);
                       let src_sector = Int64.mul src sectors_per_cluster in
@@ -903,7 +903,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
                       >>*= fun () ->
                       update_progress ();
                       let substitutions = ClusterMap.add src dst substitutions in
-                      Lwt.return (`Ok (move :: moves, map, substitutions))
+                      Lwt.return (`Ok (move :: moves, new_map, substitutions))
                     end
                   ) map ([], map, ClusterMap.empty)
                 >>*= fun (moves, map, substitutions) ->

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1097,7 +1097,11 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
         t.stats.nr_unmapped <- 0L;
         compact t ()
         >>= function
-        | `Ok _report -> Lwt.return_unit
+        | `Ok report ->
+          Log.info (fun f -> f "%Ld sectors copied, %Ld references updated, file shrunk by %Ld sectors"
+            report.copied report.refs_updated (Int64.sub report.old_size report.new_size)
+          );
+          Lwt.return_unit
         | `Error e ->
           Log.err (fun f -> f "background compaction returned error");
           Lwt.return_unit

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -729,7 +729,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
         cluster
       end in
 
-    let acc = make ~free ~references:ClusterMap.empty ~first_movable_cluster in
+    let acc = make ~free ~first_movable_cluster in
     (* scan the refcount table *)
     let rec loop acc i =
       if i >= Int64.of_int32 t.h.Header.refcount_table_clusters

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -838,143 +838,150 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     let cancel_requested = ref false in
 
     let th, u = Lwt.task () in
-    Lwt.on_cancel th (fun () -> cancel_requested := true);
+    Lwt.on_cancel th (fun () ->
+      Log.info (fun f -> f "cancellation of compact requested");
+      cancel_requested := true
+    );
     (* Catch stray exceptions and return as unknown errors *)
     let open Lwt.Infix in
-    Lwt.catch
+    Lwt.async
       (fun () ->
-        Qcow_rwlock.with_write_lock t.metadata_lock
+        Lwt.catch
           (fun () ->
-            let open Qcow_cluster_map in
-            make_cluster_map t
-            >>*= fun map ->
+            Qcow_rwlock.with_write_lock t.metadata_lock
+              (fun () ->
+                let open Qcow_cluster_map in
+                make_cluster_map t
+                >>*= fun map ->
 
-            Log.debug (fun f -> f "Physical blocks discovered: %Ld" (total_free map));
-            Log.debug (fun f -> f "Total free blocks discovered: %Ld" (total_free map));
-            let start_last_block = get_last_block map in
+                Log.debug (fun f -> f "Physical blocks discovered: %Ld" (total_free map));
+                Log.debug (fun f -> f "Total free blocks discovered: %Ld" (total_free map));
+                let start_last_block = get_last_block map in
 
-            let one_cluster = malloc t.h in
-            let sector_size = Int64.of_int t.base_info.B.sector_size in
-            let cluster_bits = Int32.to_int t.h.Header.cluster_bits in
-            let sectors_per_cluster = Int64.div (1L <| cluster_bits) sector_size in
+                let one_cluster = malloc t.h in
+                let sector_size = Int64.of_int t.base_info.B.sector_size in
+                let cluster_bits = Int32.to_int t.h.Header.cluster_bits in
+                let sectors_per_cluster = Int64.div (1L <| cluster_bits) sector_size in
 
-            (* An initial run through only to calculate the total work. We shall
-               treat a block copy and a reference rewrite as a single unit of work
-               even though a block copy is probably bigger. *)
-            compact_s (fun _ _ total_work -> Lwt.return (`Ok (total_work + 2))) map 0
-            >>*= fun total_work ->
+                (* An initial run through only to calculate the total work. We shall
+                   treat a block copy and a reference rewrite as a single unit of work
+                   even though a block copy is probably bigger. *)
+                compact_s (fun _ _ total_work -> Lwt.return (`Ok (total_work + 2))) map 0
+                >>*= fun total_work ->
 
-            (* We shall treat a block copy and a reference rewrite as a single unit of
-               work even though a block copy is probably bigger. *)
-            let update_progress =
-              let progress_so_far = ref 0 in
-              let last_percent = ref (-1) in
-              fun () ->
-                incr progress_so_far;
-                let percent = (100 * !progress_so_far) / total_work in
-                if !last_percent <> percent then begin
-                  progress_cb ~percent;
-                  last_percent := percent
-                end in
+                (* We shall treat a block copy and a reference rewrite as a single unit of
+                   work even though a block copy is probably bigger. *)
+                let update_progress =
+                  let progress_so_far = ref 0 in
+                  let last_percent = ref (-1) in
+                  fun () ->
+                    incr progress_so_far;
+                    let percent = (100 * !progress_so_far) / total_work in
+                    if !last_percent <> percent then begin
+                      progress_cb ~percent;
+                      last_percent := percent
+                    end in
 
-            (* Copy the blocks and build up a substitution map so we know where the referring
-               block has been copied to. (Otherwise we may go to adjust the referring block
-               only to find it has also been moved) *)
-            compact_s
-              (fun ({ src; dst; _ } as move) map (moves, _, substitutions) ->
-                if !cancel_requested
-                then Lwt.return (`Ok (moves, map, substitutions))
-                else begin
-                  Log.debug (fun f -> f "Copy cluster %Ld to %Ld" src dst);
-                  let src_sector = Int64.mul src sectors_per_cluster in
-                  let dst_sector = Int64.mul dst sectors_per_cluster in
-                  read_base t.base src_sector one_cluster
-                  >>*= fun () ->
-                  B.write t.base dst_sector [ one_cluster ]
-                  >>*= fun () ->
-                  (* If these were metadata blocks (e.g. L2 table entries) then they might
-                     be cached. Remove the overwritten block's cache entry just in case. *)
-                  ClusterCache.remove t.cache dst
-                  >>*= fun () ->
-                  update_progress ();
-                  let substitutions = ClusterMap.add src dst substitutions in
-                  Lwt.return (`Ok (move :: moves, map, substitutions))
-                end
-              ) map ([], map, ClusterMap.empty)
-            >>*= fun (moves, map, substitutions) ->
+                (* Copy the blocks and build up a substitution map so we know where the referring
+                   block has been copied to. (Otherwise we may go to adjust the referring block
+                   only to find it has also been moved) *)
+                compact_s
+                  (fun ({ src; dst; _ } as move) map (moves, _, substitutions) ->
+                    if !cancel_requested
+                    then Lwt.return (`Ok (moves, map, substitutions))
+                    else begin
+                      Log.debug (fun f -> f "Copy cluster %Ld to %Ld" src dst);
+                      let src_sector = Int64.mul src sectors_per_cluster in
+                      let dst_sector = Int64.mul dst sectors_per_cluster in
+                      read_base t.base src_sector one_cluster
+                      >>*= fun () ->
+                      B.write t.base dst_sector [ one_cluster ]
+                      >>*= fun () ->
+                      (* If these were metadata blocks (e.g. L2 table entries) then they might
+                         be cached. Remove the overwritten block's cache entry just in case. *)
+                      ClusterCache.remove t.cache dst
+                      >>*= fun () ->
+                      update_progress ();
+                      let substitutions = ClusterMap.add src dst substitutions in
+                      Lwt.return (`Ok (move :: moves, map, substitutions))
+                    end
+                  ) map ([], map, ClusterMap.empty)
+                >>*= fun (moves, map, substitutions) ->
 
-            (* Flush now so that if we crash after updating some of the references, the
-               destination blocks will contain the correct data. *)
-            B.flush t.base
-            >>*= fun () ->
+                (* Flush now so that if we crash after updating some of the references, the
+                   destination blocks will contain the correct data. *)
+                B.flush t.base
+                >>*= fun () ->
 
-            (* fold_left_s over Block.error Lwt.t values *)
-            let rec fold_left_s f acc =
-              let open Lwt.Infix in function
-              | [] -> Lwt.return (`Ok acc)
-              | x :: xs ->
-                begin f acc x >>= function
-                | `Ok acc -> fold_left_s f acc xs
-                | `Error e -> Lwt.return (`Error e)
-                end in
+                (* fold_left_s over Block.error Lwt.t values *)
+                let rec fold_left_s f acc =
+                  let open Lwt.Infix in function
+                  | [] -> Lwt.return (`Ok acc)
+                  | x :: xs ->
+                    begin f acc x >>= function
+                    | `Ok acc -> fold_left_s f acc xs
+                    | `Error e -> Lwt.return (`Error e)
+                    end in
 
-            (* Rewrite the block references, taking care to follow the substitutions map *)
-            fold_left_s
-              (fun () { Move.src; dst; update = ref_cluster, ref_cluster_within } ->
-                update_progress ();
-                let ref_cluster' =
-                  if ClusterMap.mem ref_cluster substitutions
-                  then ClusterMap.find ref_cluster substitutions
-                  else ref_cluster in
-                ClusterCache.update t.cache ref_cluster'
-                  (fun buf ->
-                    (* Read the current value in the referencing cluster as a sanity check *)
-                    ( match Physical.read (Cstruct.shift buf ref_cluster_within) with
-                      | Error (`Msg m) -> Lwt.return (`Error (`Unknown m))
-                      | Ok (old_reference, _) -> Lwt.return (`Ok old_reference) )
-                    >>*= fun old_reference ->
-                    let old_cluster, _ = Physical.to_cluster ~cluster_bits old_reference in
-                    ( if old_cluster <> src then begin
-                        Log.err (fun f -> f "Rewriting reference in %Ld (was %Ld) :%d from %Ld to %Ld, old reference actually pointing to %Ld" ref_cluster' ref_cluster ref_cluster_within src dst old_cluster);
-                        Lwt.return (`Error (`Unknown "Failed to rewrite cluster reference"))
-                      end else Lwt.return (`Ok ()) )
-                    >>*= fun () ->
-                    (* Preserve any flags but update the pointer *)
-                    let new_reference = Physical.make ~is_mutable:(Physical.is_mutable old_reference) ~is_compressed:(Physical.is_compressed old_reference) (dst <| cluster_bits) in
-                    match Physical.write new_reference (Cstruct.shift buf ref_cluster_within) with
-                    | Error (`Msg m) -> Lwt.return (`Error (`Unknown m))
-                    | Ok _ -> Lwt.return (`Ok ())
-                  )
-              ) () moves
-            >>*= fun () ->
+                (* Rewrite the block references, taking care to follow the substitutions map *)
+                fold_left_s
+                  (fun () { Move.src; dst; update = ref_cluster, ref_cluster_within } ->
+                    update_progress ();
+                    let ref_cluster' =
+                      if ClusterMap.mem ref_cluster substitutions
+                      then ClusterMap.find ref_cluster substitutions
+                      else ref_cluster in
+                    ClusterCache.update t.cache ref_cluster'
+                      (fun buf ->
+                        (* Read the current value in the referencing cluster as a sanity check *)
+                        ( match Physical.read (Cstruct.shift buf ref_cluster_within) with
+                          | Error (`Msg m) -> Lwt.return (`Error (`Unknown m))
+                          | Ok (old_reference, _) -> Lwt.return (`Ok old_reference) )
+                        >>*= fun old_reference ->
+                        let old_cluster, _ = Physical.to_cluster ~cluster_bits old_reference in
+                        ( if old_cluster <> src then begin
+                            Log.err (fun f -> f "Rewriting reference in %Ld (was %Ld) :%d from %Ld to %Ld, old reference actually pointing to %Ld" ref_cluster' ref_cluster ref_cluster_within src dst old_cluster);
+                            Lwt.return (`Error (`Unknown "Failed to rewrite cluster reference"))
+                          end else Lwt.return (`Ok ()) )
+                        >>*= fun () ->
+                        (* Preserve any flags but update the pointer *)
+                        let new_reference = Physical.make ~is_mutable:(Physical.is_mutable old_reference) ~is_compressed:(Physical.is_compressed old_reference) (dst <| cluster_bits) in
+                        match Physical.write new_reference (Cstruct.shift buf ref_cluster_within) with
+                        | Error (`Msg m) -> Lwt.return (`Error (`Unknown m))
+                        | Ok _ -> Lwt.return (`Ok ())
+                      )
+                  ) () moves
+                >>*= fun () ->
 
-            (* Flush now so that the pointers are persisted before we truncate the file *)
-            B.flush t.base
-            >>*= fun () ->
+                (* Flush now so that the pointers are persisted before we truncate the file *)
+                B.flush t.base
+                >>*= fun () ->
 
-            let last_block = get_last_block map in
-            Log.debug (fun f -> f "Shrink file so that last cluster was %Ld, now %Ld" start_last_block last_block);
-            t.next_cluster <- Int64.succ last_block;
-            Cluster.allocate_clusters t 0L (* takes care of the file size *)
-            >>*= fun _ ->
+                let last_block = get_last_block map in
+                Log.debug (fun f -> f "Shrink file so that last cluster was %Ld, now %Ld" start_last_block last_block);
+                t.next_cluster <- Int64.succ last_block;
+                Cluster.allocate_clusters t 0L (* takes care of the file size *)
+                >>*= fun _ ->
 
-            Log.debug (fun f -> f "Physical blocks remaining: %Ld" (total_free map));
-            Log.debug (fun f -> f "Total free blocks remaining: %Ld" (total_free map));
+                Log.debug (fun f -> f "Physical blocks remaining: %Ld" (total_free map));
+                Log.debug (fun f -> f "Total free blocks remaining: %Ld" (total_free map));
 
-            progress_cb ~percent:100;
+                progress_cb ~percent:100;
 
-            let refs_updated = Int64.of_int (List.length moves) in
-            let copied = Int64.mul refs_updated sectors_per_cluster in (* one ref per block *)
-            let old_size = Int64.mul start_last_block sectors_per_cluster in
-            let new_size = Int64.mul last_block sectors_per_cluster in
-            let report = { refs_updated; copied; old_size; new_size } in
-            Lwt.return (`Ok report)
+                let refs_updated = Int64.of_int (List.length moves) in
+                let copied = Int64.mul refs_updated sectors_per_cluster in (* one ref per block *)
+                let old_size = Int64.mul start_last_block sectors_per_cluster in
+                let new_size = Int64.mul last_block sectors_per_cluster in
+                let report = { refs_updated; copied; old_size; new_size } in
+                Lwt.return (`Ok report)
+            )
+        ) (fun e ->
+          Lwt.return (`Error (`Unknown (Printexc.to_string e)))
         )
-    ) (fun e ->
-      Lwt.return (`Error (`Unknown (Printexc.to_string e)))
-    )
-    >>= fun result ->
-    Lwt.wakeup u result;
+        >>= fun result ->
+        Lwt.wakeup u result;
+        Lwt.return_unit
+      );
     th
 
   let seek_mapped_already_locked t from =

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -651,6 +651,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
       end
 
   let read t sector bufs =
+    Timer.cancel t.background_compact_timer;
     Qcow_rwlock.with_read_lock t.metadata_lock
       (fun () ->
         let cluster_size = 1L <| t.cluster_bits in
@@ -672,6 +673,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
       )
 
   let write t sector bufs =
+    Timer.cancel t.background_compact_timer;
     Qcow_rwlock.with_read_lock t.metadata_lock
       (fun () ->
         let cluster_size = 1L <| t.cluster_bits in
@@ -1172,6 +1174,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     end
 
   let discard t ~sector ~n () =
+    Timer.cancel t.background_compact_timer;
     Qcow_rwlock.with_read_lock t.metadata_lock
       (fun () ->
         (* we can only discard whole clusters. We will explicitly zero non-cluster

--- a/lib/qcow.mllib
+++ b/lib/qcow.mllib
@@ -7,4 +7,5 @@ Qcow_s
 Qcow_diet
 Qcow_rwlock
 Qcow_timer
+Qcow_cluster_map
 Qcow

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -51,6 +51,18 @@ let get_free t = t.free
 let get_references t = t.refs
 let get_first_movable_cluster t = t.first_movable_cluster
 
+let total_used t =
+  Int64.of_int @@ ClusterMap.cardinal t.refs
+
+let total_free t =
+  ClusterSet.fold
+    (fun i acc ->
+      let from = ClusterSet.Interval.x i in
+      let upto = ClusterSet.Interval.y i in
+      let size = Int64.succ (Int64.sub upto from) in
+      Int64.add size acc
+    ) t.free 0L
+
 let add t rf cluster =
   let c, w = rf in
   if cluster = 0L then t else begin

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -47,10 +47,6 @@ let make ~free ~first_movable_cluster =
   let refs = ClusterMap.empty in
   { free; refs; first_movable_cluster }
 
-let get_free t = t.free
-let get_references t = t.refs
-let get_first_movable_cluster t = t.first_movable_cluster
-
 let total_used t =
   Int64.of_int @@ ClusterMap.cardinal t.refs
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -51,18 +51,13 @@ let get_free t = t.free
 let get_references t = t.refs
 let get_first_movable_cluster t = t.first_movable_cluster
 
-(* mark a virtual -> physical mapping as in use *)
-let mark max_cluster t rf cluster =
+let add t rf cluster =
   let c, w = rf in
   if cluster = 0L then t else begin
     if ClusterMap.mem cluster t.refs then begin
       let c', w' = ClusterMap.find cluster t.refs in
       Log.err (fun f -> f "Found two references to cluster %Ld: %Ld.%d and %Ld.%d" cluster c w c' w');
       failwith (Printf.sprintf "Found two references to cluster %Ld: %Ld.%d and %Ld.%d" cluster c w c' w');
-    end;
-    if cluster > max_cluster then begin
-      Log.err (fun f -> f "Found a reference to cluster %Ld outside the file (max cluster %Ld) from cluster %Ld.%d" cluster max_cluster c w);
-      failwith (Printf.sprintf "Found a reference to cluster %Ld outside the file (max cluster %Ld) from cluster %Ld.%d" cluster max_cluster c w);
     end;
     let free = ClusterSet.(remove (Interval.make cluster cluster) t.free) in
     let refs = ClusterMap.add cluster rf t.refs in

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -1,0 +1,76 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+open Sexplib.Std
+
+let src =
+  let src = Logs.Src.create "qcow" ~doc:"qcow2-formatted BLOCK device" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Clusters = Qcow_diet.Make(struct
+  type t = int64 [@@deriving sexp]
+  let succ = Int64.succ
+  let pred = Int64.pred
+  let compare = Int64.compare
+end)
+module Int64Map = Map.Make(Int64)
+
+type t = {
+  (* unused clusters in the file. These can be safely overwritten with new data *)
+  free: Clusters.t;
+  (* map from physical cluster to the physical cluster + offset of the reference.
+     When a block is moved, this reference must be updated. *)
+  refs: (int64 * int) Int64Map.t;
+  first_movable_cluster: int64;
+}
+
+let make ~free ~references ~first_movable_cluster =
+  { free; refs=references; first_movable_cluster }
+
+let get_free t = t.free
+let get_references t = t.refs
+let get_first_movable_cluster t = t.first_movable_cluster
+
+(* mark a virtual -> physical mapping as in use *)
+let mark max_cluster t rf cluster =
+  let c, w = rf in
+  if cluster = 0L then t else begin
+    if Int64Map.mem cluster t.refs then begin
+      let c', w' = Int64Map.find cluster t.refs in
+      Log.err (fun f -> f "Found two references to cluster %Ld: %Ld.%d and %Ld.%d" cluster c w c' w');
+      failwith (Printf.sprintf "Found two references to cluster %Ld: %Ld.%d and %Ld.%d" cluster c w c' w');
+    end;
+    if cluster > max_cluster then begin
+      Log.err (fun f -> f "Found a reference to cluster %Ld outside the file (max cluster %Ld) from cluster %Ld.%d" cluster max_cluster c w);
+      failwith (Printf.sprintf "Found a reference to cluster %Ld outside the file (max cluster %Ld) from cluster %Ld.%d" cluster max_cluster c w);
+    end;
+    let free = Clusters.(remove (Interval.make cluster cluster) t.free) in
+    let refs = Int64Map.add cluster rf t.refs in
+    { t with free; refs }
+  end
+
+(* Fold over all free blocks *)
+let fold_over_free f t acc =
+  let range i acc =
+    let from = Clusters.Interval.x i in
+    let upto = Clusters.Interval.y i in
+    let rec loop acc x =
+      if x = (Int64.succ upto) then acc else loop (f x acc) (Int64.succ x) in
+    loop acc from in
+  Clusters.fold range t.free acc

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -43,8 +43,9 @@ type t = {
   first_movable_cluster: int64;
 }
 
-let make ~free ~references ~first_movable_cluster =
-  { free; refs=references; first_movable_cluster }
+let make ~free ~first_movable_cluster =
+  let refs = ClusterMap.empty in
+  { free; refs; first_movable_cluster }
 
 let get_free t = t.free
 let get_references t = t.refs

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -1,0 +1,46 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t
+(** A cluster map which describes cluster usage in the file. The cluster map
+    tracks which clusters are free, and which are used, and where the references
+    are. *)
+
+module Clusters: Qcow_s.INTERVAL_SET with type elt = int64
+
+module Int64Map: Map.S with type key = int64
+
+val make: free:Clusters.t -> references:(int64 * int) Int64Map.t ->
+  first_movable_cluster:int64 -> t
+(** Given a set of free clusters, a map of references and the first
+    cluster which can be moved (i.e. that isn't fixed header), construct a
+    cluster map. *)
+
+val get_free: t -> Clusters.t
+(** Return the current set of free clusters *)
+
+val get_references: t -> (int64 * int) Int64Map.t
+(** Return the current map of references *)
+
+val get_first_movable_cluster: t -> int64
+(** Return the first movable cluster *)
+
+val mark: int64 -> t -> (int64 * int) -> int64 -> t
+(** Rename this to 'add' *)
+
+val fold_over_free: (int64 -> 'a -> 'a) -> t -> 'a -> 'a
+(** [fold_over_free f t acc] folds [f] over all the free clusters in [t] *)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -41,8 +41,9 @@ val get_references: t -> reference ClusterMap.t
 val get_first_movable_cluster: t -> cluster
 (** Return the first movable cluster *)
 
-val mark: cluster -> t -> (cluster * int) -> cluster -> t
-(** Rename this to 'add' *)
+val add: t -> reference -> cluster -> t
+(** [add t ref cluster] marks [cluster] as in-use and notes the reference from
+    [reference]. *)
 
 val fold_over_free: (cluster -> 'a -> 'a) -> t -> 'a -> 'a
 (** [fold_over_free f t acc] folds [f] over all the free clusters in [t] *)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -41,6 +41,12 @@ val get_references: t -> reference ClusterMap.t
 val get_first_movable_cluster: t -> cluster
 (** Return the first movable cluster *)
 
+val total_used: t -> int64
+(** Return the number of tracked used clusters *)
+
+val total_free: t -> int64
+(** Return the number of tracked free clusters *)
+
 val add: t -> reference -> cluster -> t
 (** [add t ref cluster] marks [cluster] as in-use and notes the reference from
     [reference]. *)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -28,11 +28,9 @@ module ClusterSet: Qcow_s.INTERVAL_SET with type elt = cluster
 
 module ClusterMap: Map.S with type key = cluster
 
-val make: free:ClusterSet.t -> references:reference ClusterMap.t ->
-  first_movable_cluster:cluster -> t
-(** Given a set of free clusters, a map of references and the first
-    cluster which can be moved (i.e. that isn't fixed header), construct a
-    cluster map. *)
+val make: free:ClusterSet.t -> first_movable_cluster:cluster -> t
+(** Given a set of free clusters, and the first cluster which can be moved
+    (i.e. that isn't fixed header), construct an empty cluster map. *)
 
 val get_free: t -> ClusterSet.t
 (** Return the current set of free clusters *)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -20,27 +20,31 @@ type t
     tracks which clusters are free, and which are used, and where the references
     are. *)
 
-module Clusters: Qcow_s.INTERVAL_SET with type elt = int64
+type cluster = int64
 
-module Int64Map: Map.S with type key = int64
+type reference = cluster * int (* cluster * offset within cluster *)
 
-val make: free:Clusters.t -> references:(int64 * int) Int64Map.t ->
-  first_movable_cluster:int64 -> t
+module ClusterSet: Qcow_s.INTERVAL_SET with type elt = cluster
+
+module ClusterMap: Map.S with type key = cluster
+
+val make: free:ClusterSet.t -> references:reference ClusterMap.t ->
+  first_movable_cluster:cluster -> t
 (** Given a set of free clusters, a map of references and the first
     cluster which can be moved (i.e. that isn't fixed header), construct a
     cluster map. *)
 
-val get_free: t -> Clusters.t
+val get_free: t -> ClusterSet.t
 (** Return the current set of free clusters *)
 
-val get_references: t -> (int64 * int) Int64Map.t
+val get_references: t -> reference ClusterMap.t
 (** Return the current map of references *)
 
-val get_first_movable_cluster: t -> int64
+val get_first_movable_cluster: t -> cluster
 (** Return the first movable cluster *)
 
-val mark: int64 -> t -> (int64 * int) -> int64 -> t
+val mark: cluster -> t -> (cluster * int) -> cluster -> t
 (** Rename this to 'add' *)
 
-val fold_over_free: (int64 -> 'a -> 'a) -> t -> 'a -> 'a
+val fold_over_free: (cluster -> 'a -> 'a) -> t -> 'a -> 'a
 (** [fold_over_free f t acc] folds [f] over all the free clusters in [t] *)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -32,15 +32,6 @@ val make: free:ClusterSet.t -> first_movable_cluster:cluster -> t
 (** Given a set of free clusters, and the first cluster which can be moved
     (i.e. that isn't fixed header), construct an empty cluster map. *)
 
-val get_free: t -> ClusterSet.t
-(** Return the current set of free clusters *)
-
-val get_references: t -> reference ClusterMap.t
-(** Return the current map of references *)
-
-val get_first_movable_cluster: t -> cluster
-(** Return the first movable cluster *)
-
 val total_used: t -> int64
 (** Return the number of tracked used clusters *)
 

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -133,6 +133,14 @@ module Make(Elt: ELT) = struct
       let acc = f (n.x, n.y) acc in
       fold f n.r acc
 
+  let rec fold_s f t acc = match t with
+    | Empty -> Lwt.return acc
+    | Node n ->
+      let open Lwt.Infix in
+      fold_s f n.l acc >>= fun acc ->
+      f (n.x, n.y) acc >>= fun acc ->
+      fold_s f n.r acc
+
   (* fold over individual elements *)
   let fold_individual f t acc =
     let range (from, upto) acc =

--- a/lib/qcow_diet.mli
+++ b/lib/qcow_diet.mli
@@ -28,70 +28,7 @@ module type ELT = sig
   (** Successor of an element *)
 end
 
-module Make(Elt: ELT): sig
-  (** A discrete interval encoding tree: a set of elements optimised for cases
-      where large numbers of contiguous elements are in the set. *)
-
-  type elt = Elt.t [@@deriving sexp]
-  (** The type of the set elements *)
-
-  type interval
-  (** An interval: a range (x, y) of set values where all the elements from
-      x to y inclusive are in the set *)
-
-  module Interval: sig
-    val make: elt -> elt -> interval
-    (** [make first last] construct an interval describing all the elements from
-        [first] to [last] inclusive. *)
-
-    val x: interval -> elt
-    (** the starting element of the interval *)
-
-    val y: interval -> elt
-    (** the ending element of the interval *)
-  end
-
-  type t [@@deriving sexp]
-  (** The type of sets *)
-
-  val empty: t
-  (** The empty set *)
-
-  val is_empty: t -> bool
-  (** Test whether a set is empty or not *)
-
-  val mem: elt -> t -> bool
-  (** [mem elt t] tests whether [elt] is in set [t] *)
-
-  val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
-  (** [fold f t acc] folds [f] across all the intervals in [t] *)
-
-  val add: interval -> t -> t
-  (** [add interval t] returns the set consisting of [t] plus [interval] *)
-
-  val remove: interval -> t -> t
-  (** [remove interval t] returns the set consisting of [t] minus [interval] *)
-
-  val min_elt: t -> interval
-  (** [min_elt t] returns the smallest (in terms of the ordering) interval in
-      [t], or raises [Not_found] if the set is empty. *)
-
-  val max_elt: t -> interval
-  (** [max_elt t] returns the largest (in terms of the ordering) interval in
-      [t], or raises [Not_found] if the set is empty. *)
-
-  val choose: t -> interval
-  (** [choose t] returns one interval, or raises Not_found if the set is empty *)
-
-  val union: t -> t -> t
-  (** set union *)
-
-  val diff: t -> t -> t
-  (** set difference *)
-
-  val inter: t -> t -> t
-  (** set intersection *)
-end
+module Make(Elt: ELT): Qcow_s.INTERVAL_SET with type elt = Elt.t
 
 module Test: sig
   val all: (string * (unit -> unit)) list

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -75,3 +75,65 @@ module type DEBUG = sig
 
   val set_next_cluster: t -> int64 -> unit
 end
+
+module type INTERVAL_SET = sig
+  type elt
+  (** The type of the set elements *)
+
+  type interval
+  (** An interval: a range (x, y) of set values where all the elements from
+      x to y inclusive are in the set *)
+
+  module Interval: sig
+    val make: elt -> elt -> interval
+    (** [make first last] construct an interval describing all the elements from
+        [first] to [last] inclusive. *)
+
+    val x: interval -> elt
+    (** the starting element of the interval *)
+
+    val y: interval -> elt
+    (** the ending element of the interval *)
+  end
+
+  type t [@@deriving sexp]
+  (** The type of sets *)
+
+  val empty: t
+  (** The empty set *)
+
+  val is_empty: t -> bool
+  (** Test whether a set is empty or not *)
+
+  val mem: elt -> t -> bool
+  (** [mem elt t] tests whether [elt] is in set [t] *)
+
+  val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
+  (** [fold f t acc] folds [f] across all the intervals in [t] *)
+
+  val add: interval -> t -> t
+  (** [add interval t] returns the set consisting of [t] plus [interval] *)
+
+  val remove: interval -> t -> t
+  (** [remove interval t] returns the set consisting of [t] minus [interval] *)
+
+  val min_elt: t -> interval
+  (** [min_elt t] returns the smallest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
+  val max_elt: t -> interval
+  (** [max_elt t] returns the largest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
+  val choose: t -> interval
+  (** [choose t] returns one interval, or raises Not_found if the set is empty *)
+
+  val union: t -> t -> t
+  (** set union *)
+
+  val diff: t -> t -> t
+  (** set difference *)
+
+  val inter: t -> t -> t
+  (** set intersection *)
+end

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -111,6 +111,9 @@ module type INTERVAL_SET = sig
   val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold f t acc] folds [f] across all the intervals in [t] *)
 
+  val fold_s: (interval -> 'a -> 'a Lwt.t) -> t -> 'a -> 'a Lwt.t
+  (** [fold_s f t acc] folds [f] across all the intervals in [t] *)
+
   val add: interval -> t -> t
   (** [add interval t] returns the set consisting of [t] plus [interval] *)
 

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -75,3 +75,65 @@ module type DEBUG = sig
 
   val set_next_cluster: t -> int64 -> unit
 end
+
+module type INTERVAL_SET = sig
+  type elt
+  (** The type of the set elements *)
+
+  type interval
+  (** An interval: a range (x, y) of set values where all the elements from
+      x to y inclusive are in the set *)
+
+  module Interval: sig
+    val make: elt -> elt -> interval
+    (** [make first last] construct an interval describing all the elements from
+        [first] to [last] inclusive. *)
+
+    val x: interval -> elt
+    (** the starting element of the interval *)
+
+    val y: interval -> elt
+    (** the ending element of the interval *)
+  end
+
+  type t [@@deriving sexp]
+  (** The type of sets *)
+
+  val empty: t
+  (** The empty set *)
+
+  val is_empty: t -> bool
+  (** Test whether a set is empty or not *)
+
+  val mem: elt -> t -> bool
+  (** [mem elt t] tests whether [elt] is in set [t] *)
+
+  val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
+  (** [fold f t acc] folds [f] across all the intervals in [t] *)
+
+  val add: interval -> t -> t
+  (** [add interval t] returns the set consisting of [t] plus [interval] *)
+
+  val remove: interval -> t -> t
+  (** [remove interval t] returns the set consisting of [t] minus [interval] *)
+
+  val min_elt: t -> interval
+  (** [min_elt t] returns the smallest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
+  val max_elt: t -> interval
+  (** [max_elt t] returns the largest (in terms of the ordering) interval in
+      [t], or raises [Not_found] if the set is empty. *)
+
+  val choose: t -> interval
+  (** [choose t] returns one interval, or raises Not_found if the set is empty *)
+
+  val union: t -> t -> t
+  (** set union *)
+
+  val diff: t -> t -> t
+  (** set difference *)
+
+  val inter: t -> t -> t
+  (** set intersection *)
+end

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -111,6 +111,9 @@ module type INTERVAL_SET = sig
   val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold f t acc] folds [f] across all the intervals in [t] *)
 
+  val fold_s: (interval -> 'a -> 'a Lwt.t) -> t -> 'a -> 'a Lwt.t
+  (** [fold_s f t acc] folds [f] across all the intervals in [t] *)
+
   val add: interval -> t -> t
   (** [add interval t] returns the set consisting of [t] plus [interval] *)
 

--- a/lib/qcow_timer.mli
+++ b/lib/qcow_timer.mli
@@ -34,4 +34,7 @@ module Make(Time: V1_LWT.TIME): sig
       If no task is running then any existing scheduled task is removed and a
       new one is scheduled for [duration_ms] from now.
   *)
+
+  val cancel: t -> unit
+  (** If an operation is in progress, cancel and reschedule it. *)
 end


### PR DESCRIPTION
Clients like Linux become upset if I/O is blocked for too long -- for Linux this seems to be more than 30s. This PR makes the `compact` operation safely cancellable and modifies `read` `write` and `discard` to cancel any in-progress `compact`. If a `compact` is cancelled, it is rescheduled for 1s in the future.