### PR TITLE
check: cope with concurrent file modification

### DIFF
--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -190,8 +190,6 @@ let check filename =
   let t =
     Block.connect filename
     >>= fun x ->
-    B.connect x
-    >>= fun x ->
     B.check x
     >>= function
     | Error _ -> failwith (Printf.sprintf "Qcow consistency check failed on %s" filename)

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -188,16 +188,43 @@ let check filename =
   let module B = Qcow.Make(Block)(Time) in
   let open Lwt in
   let t =
-    Block.connect filename
-    >>= fun x ->
-    B.check x
-    >>= function
-    | Error _ -> failwith (Printf.sprintf "Qcow consistency check failed on %s" filename)
-    | Ok x ->
-      Printf.printf "Qcow file seems intact.\n";
-      Printf.printf "Total free blocks: %Ld\n" x.B.free;
-      Printf.printf "Total used blocks: %Ld\n" x.B.used;
-      return (`Ok ()) in
+  let rec retry = function
+    | 0 ->
+      Printf.fprintf stderr "Warning: file is being concurrently modified\n";
+      Printf.fprintf stderr "We found no concrete problems, but the file is being modified too\n";
+      Printf.fprintf stderr "quickly for us to read a consistent view.\n";
+      return (`Ok ())
+    | n ->
+      Block.connect filename
+      >>= fun block ->
+      B.check block
+      >>= function
+      | Error (`Reference_outside_file(src, dst)) ->
+        begin
+          Block.disconnect block
+          >>= fun () ->
+          Block.connect filename
+          >>= fun block ->
+          Block.get_info block
+          >>= fun info ->
+          let size = Int64.(mul info.Mirage_block.size_sectors (of_int info.Mirage_block.sector_size)) in
+          if dst > size then begin
+            Printf.fprintf stderr "Error: detected a reference outside the file, from %Ld to %Ld while the file size is %Ld\n%!" src dst size;
+            exit 1
+          end else begin
+            (* The file has grown, try again *)
+            Block.disconnect block
+            >>= fun () ->
+            retry (n - 1)
+          end
+        end
+      | Error _ -> failwith (Printf.sprintf "Qcow consistency check failed on %s" filename)
+      | Ok x ->
+        Printf.printf "Qcow file seems intact.\n";
+        Printf.printf "Total free blocks: %Ld\n" x.B.free;
+        Printf.printf "Total used blocks: %Ld\n" x.B.used;
+        return (`Ok ()) in
+        retry 5 in
   Lwt_main.run t
 
 exception Non_zero

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1013,27 +1013,6 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     used: int64;
   }
 
-  let check t =
-    Qcow_rwlock.with_write_lock t.metadata_lock
-      (fun () ->
-        let open Lwt.Infix in
-        let open Qcow_cluster_map in
-        Lwt.catch
-          (fun () ->
-            make_cluster_map t
-            >>= function
-            | Error `Disconnected -> Lwt.return (Error `Disconnected)
-            | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
-            | Error (`Msg m) -> Lwt.return (Error (`Msg m))
-            | Ok block_map ->
-            let free = total_free block_map in
-            let used = total_used block_map in
-            Lwt.return (Ok { free; used })
-          ) (function
-            | Reference_outside_file(src, dst) -> Lwt.return (Error (`Reference_outside_file(src, dst)))
-            | e -> Lwt.fail e)
-      )
-
   type compact_result = {
       copied:       int64;
       refs_updated: int64;
@@ -1346,15 +1325,38 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
       | Ok (h, _) ->
         make config base h
         >>= fun t ->
-        check t
+        make_cluster_map t
         >>= function
         | Error (`Reference_outside_file (src, dst)) -> Lwt.fail_with (Printf.sprintf "reference from %Ld to outside file %Ld: image is corrupt" src dst)
         | Error `Unimplemented -> Lwt.fail_with "Unimplemented"
         | Error `Disconnected -> Lwt.fail_with "Disconnected"
         | Error (`Msg m) -> Lwt.fail_with m
-        | Ok { free; used } ->
+        | Ok block_map ->
+        let open Qcow_cluster_map in
+        let free = total_free block_map in
+        let used = total_used block_map in
         Log.info (fun f -> f "image has %Ld free sectors and %Ld used sectors" free used);
         Lwt.return t
+
+  let check base =
+    let open Lwt.Infix in
+    connect base
+    >>= fun t ->
+    let open Qcow_cluster_map in
+    Lwt.catch
+      (fun () ->
+        make_cluster_map t
+        >>= function
+        | Error `Disconnected -> Lwt.return (Error `Disconnected)
+        | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+        | Error (`Msg m) -> Lwt.return (Error (`Msg m))
+        | Ok block_map ->
+        let free = total_free block_map in
+        let used = total_used block_map in
+        Lwt.return (Ok { free; used })
+      ) (function
+        | Reference_outside_file(src, dst) -> Lwt.return (Error (`Reference_outside_file(src, dst)))
+        | e -> Lwt.fail e)
 
   let resize t ~new_size:requested_size_bytes ?(ignore_data_loss=false) () =
     Qcow_rwlock.with_write_lock t.metadata_lock

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1011,12 +1011,16 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
   }
 
   let check t =
-    let open Lwt_error.Infix in
     Qcow_rwlock.with_write_lock t.metadata_lock
       (fun () ->
+        let open Lwt.Infix in
         let open Qcow_cluster_map in
         make_cluster_map t
-        >>= fun block_map ->
+        >>= function
+        | Error `Disconnected -> Lwt.return (Error `Disconnected)
+        | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+        | Error (`Msg m) -> Lwt.return (Error (`Msg m))
+        | Ok block_map ->
         let free = total_free block_map in
         let used = total_used block_map in
         Lwt.return (Ok { free; used })
@@ -1334,13 +1338,14 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
       | Ok (h, _) ->
         make config base h
         >>= fun t ->
-        ( if config.Config.check_on_connect then begin
-            Lwt_error.or_fail_with @@ check t
-            >>= fun { free; used } ->
-            Log.info (fun f -> f "image has %Ld free sectors and %Ld used sectors" free used);
-            Lwt.return_unit
-          end else Lwt.return_unit )
-        >>= fun () ->
+        check t
+        >>= function
+        | Error (`Reference_outside_file (src, dst)) -> Lwt.fail_with (Printf.sprintf "reference from %Ld to outside file %Ld: image is corrupt" src dst)
+        | Error `Unimplemented -> Lwt.fail_with "Unimplemented"
+        | Error `Disconnected -> Lwt.fail_with "Disconnected"
+        | Error (`Msg m) -> Lwt.fail_with m
+        | Ok { free; used } ->
+        Log.info (fun f -> f "image has %Ld free sectors and %Ld used sectors" free used);
         Lwt.return t
 
   let resize t ~new_size:requested_size_bytes ?(ignore_data_loss=false) () =

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -110,7 +110,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
     used: int64; (** used sectors *)
   }
 
-  val check: t -> (check_result, [
+  val check: B.t -> (check_result, [
     Mirage_block.error
     | `Reference_outside_file of int64 * int64
     | `Msg of string

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -110,8 +110,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
     used: int64; (** used sectors *)
   }
 
-  val check: t -> (check_result, error) result io
-  (** [check t] performs sanity checks of the file, looking for errors *)
+  val check: t -> (check_result, [
+    Mirage_block.error
+    | `Reference_outside_file of int64 * int64
+    | `Msg of string
+  ]) result io
+  (** [check t] performs sanity checks of the file, looking for errors.
+      The error [`Reference_outside_file (src, dst)] means that at offset [src]
+      there is a reference to offset [dst] which is outside the file. *)
 
   val header: t -> Header.t
   (** Return a snapshot of the current header *)


### PR DESCRIPTION
Previously `qcow-tool check` would fail if blocks were being concurrently allocated because we would find pointers outside the file. This PR enhances the error types from `connect` and `check` to describe this situation and makes `qcow-tool check` run up to 5 iterations attempting to get a consistent picture of the file. If `qcow-tool check` detects real damage, it always fails. If it detects a pointer outside the file which is actually now inside the file (due to expansion) it repeats up to 5 times.

For example
```
main.native: [ERROR] Found a reference to cluster 107384 outside the file (max cluster 107383) from cluster 105855.12016
main.native: [ERROR] Found a reference to cluster 108409 outside the file (max cluster 108408) from cluster 105855.20216
main.native: [ERROR] Found a reference to cluster 109562 outside the file (max cluster 109561) from cluster 105855.29440
main.native: [ERROR] Found a reference to cluster 111366 outside the file (max cluster 111365) from cluster 105855.43872
main.native: [ERROR] Found a reference to cluster 112479 outside the file (max cluster 112478) from cluster 105855.52776
Warning: file is being concurrently modified
We found no concrete problems, but the file is being modified too
quickly for us to read a consistent view.
```