### PR TITLE
Auto compact after 10s rather than 1s

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -47,11 +47,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     type t = {
       discard: bool;
       compact_after_unmaps: int64 option;
+      compact_ms: int;
     }
-    let create ?(discard=false) ?compact_after_unmaps () = { discard; compact_after_unmaps }
-    let to_string t = Printf.sprintf "discard=%b;compact_after_unmaps=%s"
+    let create ?(discard=false) ?compact_after_unmaps ?(compact_ms=1000) () =
+      { discard; compact_after_unmaps; compact_ms }
+    let to_string t = Printf.sprintf "discard=%b;compact_after_unmaps=%s;compact_ms=%d"
       t.discard (match t.compact_after_unmaps with None -> "0" | Some x -> Int64.to_string x)
-    let default = { discard = false; compact_after_unmaps = None }
+      t.compact_ms
+    let default = { discard = false; compact_after_unmaps = None; compact_ms = 1000 }
     let of_string txt =
       let open Astring in
       try
@@ -65,6 +68,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
             | "compact_after_unmaps" ->
               let compact_after_unmaps = if v = "0" then None else Some (Int64.of_string v) in
               { t with compact_after_unmaps }
+            | "compact_ms" -> { t with compact_ms = int_of_string v }
             | x -> failwith ("Unknown qcow configuration key: " ^ x)
             end
         ) default strings)
@@ -1217,7 +1221,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     >>*= fun () ->
     match t.config.compact_after_unmaps with
     | Some sectors when t.stats.nr_unmapped > sectors ->
-      Timer.restart ~duration_ms:1000 t.background_compact_timer;
+      Timer.restart ~duration_ms:t.config.Config.compact_ms t.background_compact_timer;
       Lwt.return (`Ok ())
     | _ -> Lwt.return (`Ok ())
 

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -49,12 +49,12 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
       compact_after_unmaps: int64 option;
       compact_ms: int;
     }
-    let create ?(discard=false) ?compact_after_unmaps ?(compact_ms=1000) () =
+    let create ?(discard=false) ?compact_after_unmaps ?(compact_ms=10000) () =
       { discard; compact_after_unmaps; compact_ms }
     let to_string t = Printf.sprintf "discard=%b;compact_after_unmaps=%s;compact_ms=%d"
       t.discard (match t.compact_after_unmaps with None -> "0" | Some x -> Int64.to_string x)
       t.compact_ms
-    let default = { discard = false; compact_after_unmaps = None; compact_ms = 1000 }
+    let default = { discard = false; compact_after_unmaps = None; compact_ms = 10000 }
     let of_string txt =
       let open Astring in
       try

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -24,11 +24,13 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) : sig
     type t = {
       discard: bool; (** true if `discard` will be enabled at runtime *)
       compact_after_unmaps: int64 option; (** automatically compact after n sectors are unmapped *)
+      compact_ms: int; (** if automatically compacting, wait for this many milliseconds *)
     }
     (** Runtime configuration of a device *)
 
-    val create: ?discard:bool -> ?compact_after_unmaps:int64 -> unit -> t
-    (** [create ?discard ?compact_after_unmaps ()] constructs a runtime configuration *)
+    val create: ?discard:bool -> ?compact_after_unmaps:int64 ->
+      ?compact_ms:int -> unit -> t
+    (** [create ?discard ?compact_after_unmaps ?compact_ms ()] constructs a runtime configuration *)
 
     val to_string: t -> string
     (** Marshal a config into a string suitable for a command-line argument *)


### PR DESCRIPTION
Previously we would schedule an auto-compact after 1s but this may be too aggressive since it requires building up a cluster map from scratch (-- we don't yet keep a live copy). This PR makes it configurable at runtime and changes the default to 10s.