### PR TITLE
Use a bitmap for free block tracking

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,5 @@
 true : bin_annot, safe_string, package(bytes)
+true: warn_error(+1..49-42), warn(A-3-4-41-44)
 
 <lib>: include
 

--- a/cli/impl.ml
+++ b/cli/impl.ml
@@ -107,12 +107,12 @@ let progress_cb ~percent =
 
   let len = (progress_bar_width * percent) / 100 in
   for i = 0 to len - 1 do
-    line.[4 + i] <- (if i = len - 1 then '>' else '#')
+    Bytes.set line (4 + i) (if i = len - 1 then '>' else '#')
   done;
-  line.[0] <- '[';
-  line.[1] <- spinner.(!spinner_idx);
-  line.[2] <- ']';
-  line.[3] <- ' ';
+  Bytes.set line 0 '[';
+  Bytes.set line 1 spinner.(!spinner_idx);
+  Bytes.set line 2 ']';
+  Bytes.set line 3 ' ';
   spinner_idx := (!spinner_idx + 1) mod (Array.length spinner);
   let percent' = Printf.sprintf "%3d%%" percent in
   String.blit percent' 0 line (progress_bar_width + 4) 4;
@@ -285,7 +285,7 @@ let compact common_options_t unsafe_buffering filename =
   let module BLOCK = (val block: BLOCK) in
   let module B = Qcow.Make(BLOCK)(Time) in
   let open Lwt in
-  let progress_cb = if common_options_t.progress then Some progress_cb else None in
+  let progress_cb = if common_options_t.Common.progress then Some progress_cb else None in
   let t =
     BLOCK.connect filename
     >>*= fun x ->

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Sexplib.Std
-open Result
 open Astring
 
 let project_url = "http://github.com/mirage/ocaml-qcow"
@@ -190,10 +188,10 @@ let resize_cmd =
   let doc = "Change the maximum virtual size of the disk." in
   let man = [
     `S "DESCRIPTION";
-    `P "When a .qcow2 file is created, the physical file on disk is small but
-       the disk has a (usually much larger) 'virtual' size as seen from the
-       perspective of the client. A disk can usually be safely increased in size
-       without harming the contents. It's up to the client whether it is able
+    `P "When a .qcow2 file is created, the physical file on disk is small but \
+       the disk has a (usually much larger) 'virtual' size as seen from the \
+       perspective of the client. A disk can usually be safely increased in size \
+       without harming the contents. It's up to the client whether it is able \
        to use the new space or not."
   ] @ help in
   Term.(ret(pure Impl.resize $ trace $ filename $ size $ ignore_data_loss)),
@@ -207,8 +205,8 @@ let discard_cmd =
   let doc = "Scan for zeroes and discard them" in
   let man = [
     `S "DESCRIPTION";
-    `P "Iterate over all allocated blocks in the image, and if a block only
-        contains zeroes, then invoke discard (aka TRIM or UNMAP) on it. This
+    `P "Iterate over all allocated blocks in the image, and if a block only \
+        contains zeroes, then invoke discard (aka TRIM or UNMAP) on it. This \
         helps shrink the blocks in the file.";
   ] @ help in
   Term.(ret(pure Impl.discard $ unsafe_buffering $ filename)),
@@ -218,7 +216,7 @@ let compact_cmd =
   let doc = "Compact the file" in
   let man = [
     `S "DESCRIPTION";
-    `P "Iterate over all the unallocated blocks ('holes') in the file created
+    `P "Iterate over all the unallocated blocks ('holes') in the file created \
         by discard and move live data into them to shrink the file.";
   ] @ help in
   Term.(ret(pure Impl.compact $ common_options_t $ unsafe_buffering $ filename)),
@@ -228,9 +226,9 @@ let repair_cmd =
   let doc = "Regenerate the refcount table in an image" in
   let man = [
     `S "DESCRIPTION";
-    `P "Regenerate the refcount table in an image to make it compliant with
-    the spec. We normally avoid updating the refcount at runtime as a
-    performance optimisation."
+    `P "Regenerate the refcount table in an image to make it compliant with \
+        the spec. We normally avoid updating the refcount at runtime as a \
+        performance optimisation."
   ] @ help in
   Term.(ret(pure Impl.repair $ unsafe_buffering $ filename)),
   Term.info "repair" ~sdocs:_common_options ~doc ~man

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -717,8 +717,8 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     (* Assume all clusters are free *)
     let free = ClusterSet.make_full (Int64.to_int t.next_cluster) in
     (* Subtract the fixed structures at the beginning of the file *)
-    ClusterSet.(remove (Interval.make l1_table_start_cluster (Int64.add l1_table_start_cluster l1_table_clusters)) free);
-    ClusterSet.(remove (Interval.make refcount_start_cluster (Int64.add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters))) free);
+    ClusterSet.(remove (Interval.make l1_table_start_cluster (Int64.(pred @@ add l1_table_start_cluster l1_table_clusters))) free);
+    ClusterSet.(remove (Interval.make refcount_start_cluster (Int64.(pred @@ add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters)))) free);
     ClusterSet.(remove (Interval.make 0L 0L) free);
     let first_movable_cluster =
       try

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -727,9 +727,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     (* Assume all clusters are free *)
     let free = ClusterSet.make_full (Int64.to_int t.next_cluster) in
     (* Subtract the fixed structures at the beginning of the file *)
-    ClusterSet.(remove (Interval.make l1_table_start_cluster (Int64.add l1_table_start_cluster l1_table_clusters)));
-    ClusterSet.(remove (Interval.make refcount_start_cluster (Int64.add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters))));
-    ClusterSet.(remove (Interval.make 0L 0L));
+    ClusterSet.(remove (Interval.make l1_table_start_cluster (Int64.add l1_table_start_cluster l1_table_clusters)) free);
+    ClusterSet.(remove (Interval.make refcount_start_cluster (Int64.add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters))) free);
+    ClusterSet.(remove (Interval.make 0L 0L) free);
     let first_movable_cluster =
       try
         ClusterSet.min_elt free

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -724,8 +724,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     let int64s_per_cluster = 1L <| (Int32.to_int t.h.Header.cluster_bits - 3) in
     let l1_table_start_cluster, _ = Physical.to_cluster ~cluster_bits:t.cluster_bits (Physical.make t.h.Header.l1_table_offset) in
     let l1_table_clusters = Int64.(div (round_up (of_int32 t.h.Header.l1_size) int64s_per_cluster) int64s_per_cluster) in
+    (* Assume all clusters are free *)
+    let free = ClusterSet.make_full (Int64.to_int t.next_cluster) in
     (* Subtract the fixed structures at the beginning of the file *)
-    let free = ClusterSet.make (Int64.to_int t.next_cluster) in
     ClusterSet.(remove (Interval.make l1_table_start_cluster (Int64.add l1_table_start_cluster l1_table_clusters)));
     ClusterSet.(remove (Interval.make refcount_start_cluster (Int64.add refcount_start_cluster (Int64.of_int32 t.h.Header.refcount_table_clusters))));
     ClusterSet.(remove (Interval.make 0L 0L));

--- a/lib/qcow.mllib
+++ b/lib/qcow.mllib
@@ -5,6 +5,7 @@ Qcow_virtual
 Qcow_physical
 Qcow_s
 Qcow_diet
+Qcow_bitmap
 Qcow_rwlock
 Qcow_timer
 Qcow_cluster_map

--- a/lib/qcow_bitmap.ml
+++ b/lib/qcow_bitmap.ml
@@ -24,10 +24,16 @@ type elt = int64
 
 type interval = elt * elt
 
-let make len =
+let make_empty len =
   let bytes_required = (len + 7) / 8 in
   let buf = Cstruct.create bytes_required in
   Cstruct.memset buf 0;
+  { buf; len }
+
+let make_full len =
+  let bytes_required = (len + 7) / 8 in
+  let buf = Cstruct.create bytes_required in
+  Cstruct.memset buf 0xff;
   { buf; len }
 
 let set t n v =
@@ -151,7 +157,7 @@ module IntSet = Set.Make(Int)
 module Test = struct
 
   let make_random n m =
-    let diet = make n in
+    let diet = make_empty n in
     let rec loop set = function
       | 0 -> set, diet
       | m ->
@@ -185,13 +191,13 @@ module Test = struct
     done
 
   let test_add_1 () =
-    let t = make 10 in
+    let t = make_empty 10 in
     add (3L, 3L) t;
     add (3L, 4L) t;
     assert (elements t = [ 3L; 4L ])
 
   let test_remove_1 () =
-    let t = make 10 in
+    let t = make_empty 10 in
     add (7L, 8L) t;
     remove (6L, 7L) t;
     assert (elements t = [ 8L ])

--- a/lib/qcow_bitmap.ml
+++ b/lib/qcow_bitmap.ml
@@ -36,6 +36,13 @@ let make_full len =
   Cstruct.memset buf 0xff;
   { buf; len }
 
+let copy t =
+  let bytes_required = Cstruct.len t.buf in
+  let buf = Cstruct.create bytes_required in
+  Cstruct.blit t.buf 0 buf 0 bytes_required;
+  let len = t.len in
+  { buf; len }
+
 let set' t n v =
   if n >= t.len then invalid_arg (Printf.sprintf "Qcow_bitmap.set %d >= %d" n t.len);
   let i = n / 8 in

--- a/lib/qcow_bitmap.ml
+++ b/lib/qcow_bitmap.ml
@@ -1,0 +1,205 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t = {
+  buf: Cstruct.t;
+  len: int;
+}
+
+type elt = int64
+
+type interval = elt * elt
+
+let make len =
+  let bytes_required = (len + 7) / 8 in
+  let buf = Cstruct.create bytes_required in
+  Cstruct.memset buf 0;
+  { buf; len }
+
+let set t n v =
+  if n >= (Int64.of_int t.len) then invalid_arg (Printf.sprintf "Qcow_bitmap.set %Ld >= %d" n t.len);
+  let i = Int64.(to_int (div n 8L)) in
+  let byte = Cstruct.get_uint8 t.buf i in
+  let byte' =
+    if v
+    then byte lor (1 lsl (Int64.(to_int (rem n 8L))))
+    else byte land (lnot (1 lsl (Int64.(to_int (rem n 8L))))) in
+  Cstruct.set_uint8 t.buf i byte'
+
+let get t n =
+  if n >= (Int64.of_int t.len) then invalid_arg (Printf.sprintf "Qcow_bitmap.get %Ld >= %d" n t.len);
+  let i = Int64.(to_int (div n 8L)) in
+  let byte = Cstruct.get_uint8 t.buf i in
+  byte land (1 lsl (Int64.(to_int (rem n 8L)))) <> 0
+
+let set' t n v =
+  if n >= t.len then invalid_arg (Printf.sprintf "Qcow_bitmap.set %d >= %d" n t.len);
+  let i = n / 8 in
+  let byte = Cstruct.get_uint8 t.buf i in
+  let byte' =
+    if v
+    then byte lor (1 lsl (n mod 8))
+    else byte land (lnot (1 lsl (n mod 8))) in
+  Cstruct.set_uint8 t.buf i byte'
+
+let get' t n =
+  if n >= t.len then invalid_arg (Printf.sprintf "Qcow_bitmap.get %d >= %d" n t.len);
+  let i = n / 8 in
+  let byte = Cstruct.get_uint8 t.buf i in
+  byte land (1 lsl (n mod 8)) <> 0
+
+module Interval = struct
+  let make x y =
+    if x > y then invalid_arg "Interval.make";
+    x, y
+  let x = fst
+  let y = snd
+end
+
+let add (a, b) t =
+  for i = Int64.to_int a to Int64.to_int b do
+    set' t i true
+  done
+
+let remove (a, b) t =
+  for i = Int64.to_int a to Int64.to_int b do
+    set' t i false
+  done
+
+let min_elt t =
+  let rec loop from =
+    if get' t from then from else loop (from + 1) in
+  try
+    Int64.of_int @@ loop 0
+  with _ -> raise Not_found
+
+(* fold over the maximal contiguous intervals *)
+let fold f t acc =
+  let rec loop acc from =
+    (* find a true element *)
+    let rec find from v =
+      if get' t from = v then from else find (from + 1) v in
+    match find from true with
+      | exception Invalid_argument _ ->
+        (* there are no more *)
+        acc
+      | a ->
+        (* find a false element, up to the end of the set *)
+        let b = match find a false with
+          | b -> b
+          | exception Invalid_argument _ -> t.len in
+        let acc = f (Int64.of_int a, Int64.of_int (b - 1)) acc in
+        loop acc b in
+  loop acc 0
+
+(* fold over the maximal contiguous intervals *)
+let fold_s f t acc =
+  let open Lwt.Infix in
+  let rec loop acc from =
+    (* find a true element *)
+    let rec find from v =
+      if get' t from = v then from else find (from + 1) v in
+    match find from true with
+      | exception Invalid_argument _ ->
+        (* there are no more *)
+        Lwt.return acc
+      | a ->
+        (* find a false element, up to the end of the set *)
+        let b = match find a false with
+          | b -> b
+          | exception Invalid_argument _ -> t.len in
+        f (Int64.of_int a, Int64.of_int (b - 1)) acc
+        >>= fun acc ->
+        loop acc b in
+  loop acc 0
+
+(* fold over individual elements *)
+let fold_individual f t acc =
+  let range (from, upto) acc =
+    let rec loop acc x =
+      if x = (Int64.succ upto) then acc else loop (f x acc) (Int64.succ x) in
+    loop acc from in
+  fold range t acc
+
+let elements t = fold_individual (fun x acc -> x :: acc) t [] |> List.rev
+
+let to_string t =
+  fold (fun (a, b) acc -> Printf.sprintf "%Ld - %Ld\n" a b :: acc) t []
+  |> String.concat ", "
+
+open Sexplib.Std
+module Int = struct
+  type t = int [@@deriving sexp]
+  let compare (x: t) (y: t) = Pervasives.compare x y
+end
+module IntSet = Set.Make(Int)
+
+module Test = struct
+
+  let make_random n m =
+    let diet = make n in
+    let rec loop set = function
+      | 0 -> set, diet
+      | m ->
+        let r = Random.int n in
+        let i = Interval.make (Int64.of_int r) (Int64.of_int r) in
+        let set, () =
+          if Random.bool ()
+          then IntSet.add r set, add i diet
+          else IntSet.remove r set, remove i diet in
+        loop set (m - 1) in
+    loop IntSet.empty m
+
+  let set_to_string set =
+    String.concat "; " @@ List.map string_of_int @@ IntSet.elements set
+
+  let check_equals set diet =
+    let set' = IntSet.elements set |> List.map Int64.of_int in
+    let diet' = elements diet in
+    if set' <> diet' then begin
+      (*
+      Printf.fprintf stderr "Set contains: [ %s ]\n" @@ set_to_string set;
+      Printf.fprintf stderr "Diet contains: [ %s ]\n" @@ diet_to_string diet;
+      *)
+      failwith "check_equals"
+    end
+
+  let test_adds () =
+    for i = 1 to 1000 do
+      let set, diet = make_random 1000 1000 in
+      check_equals set diet;
+    done
+
+  let test_add_1 () =
+    let t = make 10 in
+    add (3L, 3L) t;
+    add (3L, 4L) t;
+    assert (elements t = [ 3L; 4L ])
+
+  let test_remove_1 () =
+    let t = make 10 in
+    add (7L, 8L) t;
+    remove (6L, 7L) t;
+    assert (elements t = [ 8L ])
+
+  let all = [
+    "adding an element to the right", test_add_1;
+    "removing an element on the left", test_remove_1;
+    "adding and removing elements acts like a Set", test_adds;
+  ]
+
+end

--- a/lib/qcow_bitmap.mli
+++ b/lib/qcow_bitmap.mli
@@ -43,6 +43,9 @@ val make_empty: int -> t
 val make_full: int -> t
 (** [make_full n] creates a set of maximum size [n], initially full *)
 
+val copy: t -> t
+(** [copy t] returns a duplicate of [t] *)
+
 val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
 (** [fold f t acc] folds [f] across all the intervals in [t] *)
 

--- a/lib/qcow_bitmap.mli
+++ b/lib/qcow_bitmap.mli
@@ -60,3 +60,7 @@ val min_elt: t -> elt
     is empty. *)
 
 val to_string: t -> string
+
+module Test: sig
+  val all: (string * (unit -> unit)) list
+end

--- a/lib/qcow_bitmap.mli
+++ b/lib/qcow_bitmap.mli
@@ -1,0 +1,57 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type elt = int64
+(** The type of the set elements *)
+
+type interval
+(** An interval: a range (x, y) of set values where all the elements from
+    x to y inclusive are in the set *)
+
+module Interval: sig
+  val make: elt -> elt -> interval
+  (** [make first last] construct an interval describing all the elements from
+      [first] to [last] inclusive. *)
+
+  val x: interval -> elt
+  (** the starting element of the interval *)
+
+  val y: interval -> elt
+  (** the ending element of the interval *)
+end
+
+type t
+(** The type of sets *)
+
+val make: int -> t
+(** [make n] creates a set of maximum size [n], initially empty *)
+
+val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
+(** [fold f t acc] folds [f] across all the intervals in [t] *)
+
+val fold_s: (interval -> 'a -> 'a Lwt.t) -> t -> 'a -> 'a Lwt.t
+(** [fold_s f t acc] folds [f] across all the intervals in [t] *)
+
+val add: interval -> t -> unit
+(** [add interval t] adds the [interval] to [t] in-place *)
+
+val remove: interval -> t -> unit
+(** [remove interval t] removes the [interval] from [t] in-place *)
+
+val min_elt: t -> elt
+(** [min_elt t] returns the smallest element, or raises [Not_found] if the set
+    is empty. *)

--- a/lib/qcow_bitmap.mli
+++ b/lib/qcow_bitmap.mli
@@ -37,8 +37,11 @@ end
 type t
 (** The type of sets *)
 
-val make: int -> t
-(** [make n] creates a set of maximum size [n], initially empty *)
+val make_empty: int -> t
+(** [make_empty n] creates a set of maximum size [n], initially empty *)
+
+val make_full: int -> t
+(** [make_full n] creates a set of maximum size [n], initially full *)
 
 val fold: (interval -> 'a -> 'a) -> t -> 'a -> 'a
 (** [fold f t acc] folds [f] across all the intervals in [t] *)

--- a/lib/qcow_bitmap.mli
+++ b/lib/qcow_bitmap.mli
@@ -58,3 +58,5 @@ val remove: interval -> t -> unit
 val min_elt: t -> elt
 (** [min_elt t] returns the smallest element, or raises [Not_found] if the set
     is empty. *)
+
+val to_string: t -> string

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Sexplib.Std
 
 let src =
   let src = Logs.Src.create "qcow" ~doc:"qcow2-formatted BLOCK device" in

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -41,6 +41,12 @@ let make ~free ~first_movable_cluster =
   let refs = ClusterMap.empty in
   { free; refs; first_movable_cluster }
 
+let copy t =
+  let free = ClusterSet.copy t.free in
+  let refs = t.refs in
+  let first_movable_cluster = t.first_movable_cluster in
+  { free; refs; first_movable_cluster }
+
 let total_used t =
   Int64.of_int @@ ClusterMap.cardinal t.refs
 
@@ -91,6 +97,7 @@ let get_last_block t =
     Int64.pred t.first_movable_cluster
 
 let compact_s f t acc =
+  let t = copy t in
   (* The last allocated block. Note if there are no data blocks this will
      point to the last header block even though it is immovable. *)
   let max_cluster = get_last_block t in

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -48,7 +48,7 @@ module Move: sig
       and update the reference in cluster [update] *)
 end
 
-val compact_s: (Move.t -> t -> 'a -> [ `Ok of 'a | `Error of 'b ] Lwt.t ) -> t -> 'a
+val compact_s: (Move.t -> t -> 'a -> [ `Ok of (bool * 'a) | `Error of 'b ] Lwt.t ) -> t -> 'a
   -> [ `Ok of 'a | `Error of 'b ] Lwt.t
 (** [compact_s f t acc] accumulates the result of [f move t'] where [move] is
     the next cluster move needed to perform a compaction of [t] and [t']

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -24,7 +24,7 @@ type cluster = int64
 
 type reference = cluster * int (* cluster * offset within cluster *)
 
-module ClusterSet: Qcow_s.INTERVAL_SET with type elt = cluster
+module ClusterSet = Qcow_bitmap
 
 module ClusterMap: Map.S with type key = cluster
 
@@ -38,7 +38,7 @@ val total_used: t -> int64
 val total_free: t -> int64
 (** Return the number of tracked free clusters *)
 
-val add: t -> reference -> cluster -> t
+val add: t -> reference -> cluster -> unit
 (** [add t ref cluster] marks [cluster] as in-use and notes the reference from
     [reference]. *)
 

--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -64,7 +64,7 @@ module Make(Elt: ELT) = struct
   and node = { x: elt; y: elt; l: t; r: t }
   [@@deriving sexp]
 
-  let to_string_internal t = Sexplib.Sexp.to_string_hum @@ sexp_of_t t
+  let to_string_internal t = Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t t
 
   module Invariant = struct
 
@@ -275,12 +275,12 @@ module Test = struct
           else IntSet.remove r set, IntDiet.remove (IntDiet.Interval.make r r) diet in
         loop set diet (m - 1) in
     loop IntSet.empty IntDiet.empty m
-
+    (*
   let set_to_string set =
     String.concat "; " @@ List.map string_of_int @@ IntSet.elements set
   let diet_to_string diet =
     String.concat "; " @@ List.map string_of_int @@ IntDiet.elements diet
-
+    *)
   let check_equals set diet =
     let set' = IntSet.elements set in
     let diet' = IntDiet.elements diet in
@@ -293,7 +293,7 @@ module Test = struct
     end
 
   let test_adds () =
-    for i = 1 to 1000 do
+    for _ = 1 to 1000 do
       let set, diet = make_random 1000 1000 in
       begin
         try
@@ -308,7 +308,7 @@ module Test = struct
     done
 
   let test_operator set_op diet_op () =
-    for i = 1 to 1000 do
+    for _ = 1 to 1000 do
       let set1, diet1 = make_random 1000 1000 in
       let set2, diet2 = make_random 1000 1000 in
       check_equals set1 diet1;

--- a/lib/qcow_error.ml
+++ b/lib/qcow_error.ml
@@ -29,9 +29,3 @@ let error_msg fmt = Printf.ksprintf (fun s -> Error (`Msg s)) fmt
 let ( >>= ) m f = match m with
   | Error x -> Error x
   | Ok x -> f x
-
-let (>>*=) m f =
-  let open Lwt in
-  m >>= function
-  | `Ok x -> f x
-  | `Error x -> Lwt.return (`Error x)

--- a/lib/qcow_header.ml
+++ b/lib/qcow_header.ml
@@ -31,7 +31,7 @@ module Version = struct
     | `Three
   ] [@@deriving sexp]
 
-  let sizeof t = 4
+  let sizeof _ = 4
 
   let write t rest =
     Int32.write (match t with | `One -> 1l | `Two -> 2l | `Three -> 3l) rest
@@ -243,7 +243,6 @@ let write t rest =
   | None -> return rest
   | Some e ->
     let incompatible_features =
-      let open Int64 in
       let bits = [
         (if e.dirty then 1L <| 0 else 0L);
         (if e.corrupt then 1L <| 1 else 0L);
@@ -252,7 +251,6 @@ let write t rest =
     Int64.write incompatible_features rest
     >>= fun rest ->
     let compatible_features =
-      let open Int64 in
       let bits = [
         (if e.lazy_refcounts then 1L <| 0 else 0L);
       ] in
@@ -421,7 +419,6 @@ let read rest =
 
 let refcounts_per_cluster t =
   let cluster_bits = Int32.to_int t.cluster_bits in
-  let size = t.size in
   let cluster_size = 1L <| cluster_bits in
   (* Each reference count is 2 bytes long *)
   OldInt64.div cluster_size 2L

--- a/lib/qcow_header.mli
+++ b/lib/qcow_header.mli
@@ -23,12 +23,16 @@ module Version : sig
   ] [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
+
+  val compare: t -> t -> int
 end
 
 module CryptMethod : sig
   type t = [ `Aes | `None ] [@@deriving sexp]
 
   include Qcow_s.SERIALISABLE with type t := t
+
+  val compare: t -> t -> int
 end
 
 module Feature : sig

--- a/lib/qcow_physical.ml
+++ b/lib/qcow_physical.ml
@@ -43,14 +43,14 @@ let shift t bytes =
 
 (* Take an offset and round it down to the nearest physical sector, returning
    the sector number and an offset within the sector *)
-let rec to_sector ~sector_size t =
+let to_sector ~sector_size t =
   let x = (t <| 2) |> 2 in
   Int64.(div x (of_int sector_size)),
   Int64.(to_int (rem x (of_int sector_size)))
 
 let to_bytes t = (t <| 2) |> 2
 
-let rec to_cluster ~cluster_bits t =
+let to_cluster ~cluster_bits t =
   let x = (t <| 2) |> 2 in
   Int64.(div x (1L <| cluster_bits)),
   Int64.(to_int (rem x (1L <| cluster_bits)))
@@ -78,7 +78,6 @@ let sexp_of_t t =
 
 let t_of_sexp s =
   let _t = _t_of_sexp s in
-  let bytes = (_t.bytes <| 2) |> 2 in
   let is_mutable = if _t.is_mutable then 1L <| 63 else 0L in
   let is_compressed = if _t.is_compressed then 1L <| 62 else 0L in
   Int64.(logor (logor _t.bytes is_mutable) is_compressed)

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -16,10 +16,6 @@
 module FromBlock = Error.FromBlock
 module FromResult = Error.FromResult
 
-open Sexplib.Std
-open Qcow
-open Lwt
-open OUnit
 open Utils
 open Sizes
 

--- a/lib_test/extent.ml
+++ b/lib_test/extent.ml
@@ -33,7 +33,7 @@ type overlap =
   | ABAB
 [@@deriving sexp]
 
-let classify ({ start = a_start; length = a_length } as a) ({ start = b_start; length = b_length } as b) =
+let classify { start = a_start; length = a_length } { start = b_start; length = b_length } =
   let a_end = add a_start a_length in
   let b_end = add b_start b_length in
   if b_end < a_start

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -20,7 +20,23 @@ open Utils
 
 module Img = struct
   let create file size =
-    ignore_output @@ run "qemu-img" [ "create"; "-f"; "qcow2"; "-o"; "lazy_refcounts=on"; file; Int64.to_string size ]
+    ignore_output @@ run "qemu-img" [ "create"; "-f"; "qcow2"; "-o"; "lazy_refcounts=on"; file; Int64.to_string size ];
+    (* workaround for https://github.com/mirage/mirage-block-unix/issues/59 *)
+    Lwt_main.run begin
+      let open Lwt.Infix in
+      Lwt_unix.LargeFile.stat file
+      >>= fun stat ->
+      let bytes = stat.Lwt_unix.LargeFile.st_size in
+      let remainder = Int64.rem bytes 512L in
+      let padding_required = if remainder = 0L then 0L else Int64.sub 512L remainder in
+      Lwt_unix.openfile file [ Lwt_unix.O_WRONLY; Lwt_unix.O_APPEND ] 0o0
+      >>= fun fd ->
+      let buf = Cstruct.create (Int64.to_int padding_required) in
+      Cstruct.memset buf 0;
+      Lwt_cstruct.complete (Lwt_cstruct.write fd) buf
+      >>= fun () ->
+      Lwt_unix.close fd
+    end
 
   let check file =
     ignore_output @@ run "qemu-img" [ "check"; file ]

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -116,7 +116,7 @@ module Block = struct
     >>= fun (client, size, flags) ->
     let read_write = not(List.mem Nbd.Protocol.PerExportFlag.Read_only flags) in
     Nbd_lwt_unix.Client.get_info client
-    >>= function { sector_size } ->
+    >>= function { Nbd_lwt_unix.Client.sector_size } ->
     assert (sector_size == 1);
     let sector_size = 512 in
     let size_sectors = Int64.(div size (of_int sector_size)) in

--- a/lib_test/qemu.ml
+++ b/lib_test/qemu.ml
@@ -78,17 +78,17 @@ module Block = struct
     info: info;
   }
 
-  let get_info { info } = Lwt.return info
+  let get_info { info; _ } = Lwt.return info
 
   type id = unit
   type 'a io = 'a Lwt.t
   type page_aligned_buffer = Cstruct.t
   type error = Mirage_block.Error.error
 
-  let read { client } sector bufs =
+  let read { client; _ } sector bufs =
     Nbd_lwt_unix.Client.read client (Int64.mul sector 512L) bufs
 
-  let write { client } sector bufs =
+  let write { client; _ } sector bufs =
     Nbd_lwt_unix.Client.write client (Int64.mul sector 512L) bufs
 
   let connect file =
@@ -116,7 +116,7 @@ module Block = struct
     >>= fun (client, size, flags) ->
     let read_write = not(List.mem Nbd.Protocol.PerExportFlag.Read_only flags) in
     Nbd_lwt_unix.Client.get_info client
-    >>= function { Nbd_lwt_unix.Client.sector_size } ->
+    >>= function { Nbd_lwt_unix.Client.sector_size; _ } ->
     assert (sector_size == 1);
     let sector_size = 512 in
     let size_sectors = Int64.(div size (of_int sector_size)) in
@@ -127,7 +127,7 @@ module Block = struct
     Img.create file size;
     connect file
 
-  let disconnect { server; client; s } =
+  let disconnect { server; client; s; _ } =
     let open Lwt.Infix in
     Nbd_lwt_unix.Client.disconnect client
     >>= fun () ->

--- a/lib_test/sizes.ml
+++ b/lib_test/sizes.ml
@@ -15,12 +15,6 @@
  *)
 module FromBlock = Error.FromBlock
 
-open Sexplib.Std
-open Qcow
-open Lwt
-open OUnit
-open Utils
-
 let mib = Int64.mul 1024L 1024L
 let gib = Int64.mul mib 1024L
 let tib = Int64.mul gib 1024L
@@ -53,7 +47,7 @@ let off_by ((label', offset'), (label, offset)) = [
 ]
 
 let rec cross xs ys = match xs, ys with
-  | [], ys -> []
+  | [], _ -> []
   | x :: xs, ys -> List.map (fun y -> x, y) ys @ (cross xs ys)
 
 (* Parameterise over sector, page, cluster, more *)
@@ -66,6 +60,6 @@ let interesting_ranges sector_size size_sectors cluster_bits =
       label' ^ " @ " ^ label, offset, length'
     ) (cross (sizes sector_size cluster_bits) all) in
   List.filter
-    (fun (label, offset, length) ->
+    (fun (_label, offset, length) ->
        offset >= 0L && (Int64.add offset length <= size_bytes)
     ) all

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -16,7 +16,6 @@
 module FromBlock = Error.FromBlock
 module FromResult = Error.FromResult
 
-open Sexplib.Std
 open Qcow
 open Lwt
 open OUnit
@@ -59,7 +58,7 @@ let read_write_header name size =
     Block.connect path
     >>= fun raw ->
     B.create raw ~size ()
-    >>= fun b ->
+    >>= fun _b ->
     let open Lwt.Infix in
     repair_refcounts path
     >>= fun () ->
@@ -140,7 +139,7 @@ let rec fragment into remaining =
     let rest = Cstruct.shift remaining into in
     this :: (fragment into rest)
 
-let check_file_contents path id sector_size size_sectors (start, length) () =
+let check_file_contents path id _sector_size _size_sectors (start, length) () =
   let module RawReader = Block in
   let module Reader = Qcow.Make(RawReader)(Time) in
   let sector = Int64.div start 512L in
@@ -299,7 +298,7 @@ let check_refcount_table_allocation () =
   let t =
     Ramdisk.destroy ~name:"test";
     let open FromBlock in
-    Ramdisk.connect "test"
+    Ramdisk.connect ~name:"test"
     >>= fun ramdisk ->
     B.create ramdisk ~size:pib ()
     >>= fun b ->
@@ -321,7 +320,7 @@ let check_full_disk () =
   let t =
     Ramdisk.destroy ~name:"test";
     let open FromBlock in
-    Ramdisk.connect "test"
+    Ramdisk.connect ~name:"test"
     >>= fun ramdisk ->
     B.create ramdisk ~size:gib ()
     >>= fun b ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -730,7 +730,8 @@ let _ =
       (fun (label, start, length) -> label >:: write_discard_read_native sector_size size_sectors (start, Int64.to_int length))
       (interesting_ranges sector_size size_sectors cluster_bits) in
   let diet_tests = List.map (fun (name, fn) -> name >:: fn) Qcow_diet.Test.all in
-  let suite = "qcow2" >::: (diet_tests @ [
+  let bitmap_tests = List.map (fun (name, fn) -> name >:: fn) Qcow_bitmap.Test.all in
+  let suite = "qcow2" >::: (diet_tests @ bitmap_tests @ [
       "check we can fill the disk" >:: check_full_disk;
       "check we can reallocate the refcount table" >:: check_refcount_table_allocation;
       "create 1K" >:: create_1K;

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -151,7 +151,6 @@ let check_file_contents path id sector_size size_sectors (start, length) () =
   Reader.connect raw
   >>= fun b ->
   let expected = { Extent.start = sector; length = Int64.(div (of_int length) 512L) } in
-  let ofs' = Int64.(mul sector (of_int sector_size)) in
   Mirage_block.fold_mapped_s
     ~f:(fun bytes_seen ofs data ->
         let actual = { Extent.start = ofs; length = Int64.of_int (Cstruct.len data / 512) } in
@@ -367,10 +366,6 @@ let check_file path size =
   >>= fun qcow ->
   let h = M.header qcow in
   assert_equal ~printer:Int64.to_string size h.Qcow.Header.size;
-  let dirty =
-    match h.Qcow.Header.additional with
-    | Some { Qcow.Header.dirty = true } -> true
-    | _ -> false in
   (* Unfortunately qemu-img info doesn't query the dirty flag:
      https://github.com/djs55/qemu/commit/9ac8f24fde855c66b1378cee30791a4aef5c33ba
   assert_equal ~printer:string_of_bool dirty info.Qemu.Img.dirty_flag;


### PR DESCRIPTION
Previously we used an interval tree but this seems to be pathological when the file is not very sparse. When running `qcow-tool check` on a 42GiB non-sparse file, the runtime drops from ~50s to ~1.2s.