### PR TITLE
Add experimental support for jbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _build
 .coverage/
 *.install
 lib/qcow_word_size.ml
+*.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 dist: trusty
 env:
   global:
-    - PACKAGE="qcow-format" OCAML_VERSION=4.03
+    - PACKAGE="qcow-tool" OCAML_VERSION=4.03
+    - PINS="qcow:."
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+.PHONY: build clean test
+
+build:
+	jbuilder build @install
+
+test:
+	jbuilder runtest
+
+install:
+	jbuilder install
+
+uninstall:
+	jbuilder uninstall
+
+clean:
+	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ build:
 	jbuilder build @install
 
 test:
-	jbuilder runtest
+	jbuilder build lib_test/compact_random.exe lib_test/test.exe
+	./_build/default/lib_test/compact_random.exe -compact-mid-write -stop-after 16
+	./_build/default/lib_test/test.exe -runner sequential
 
 install:
 	jbuilder install

--- a/cli/jbuild
+++ b/cli/jbuild
@@ -1,0 +1,10 @@
+(executables
+ ((names (main))
+  (libraries   (qcow io-page.unix logs logs.fmt sha))
+  (preprocess  no_preprocessing)
+))
+
+(install
+ ((section bin)
+  (package qcow-tool)
+  (files ((main.exe as qcow-tool)))))

--- a/generator/gen.ml
+++ b/generator/gen.ml
@@ -1,6 +1,14 @@
+let output_file = ref "lib/qcow_word_size.ml"
 
 let _ =
-  let oc = open_out "lib/qcow_word_size.ml" in
+  Arg.parse [
+    "-o", Arg.Set_string output_file, "output filename"
+  ] (fun x ->
+    Printf.fprintf stderr "Unexpected argument: %s\n%!" x;
+    exit 1;
+  ) "Auto-detect the host word size";
+
+  let oc = open_out !output_file in
   begin match Sys.word_size with
   | 64 ->
     Printf.fprintf stderr "On a 64-bit machine so using 'int' for clusters\n";

--- a/generator/jbuild
+++ b/generator/jbuild
@@ -1,0 +1,4 @@
+(executables
+ ((names (gen))
+  (preprocess  no_preprocessing)
+))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,0 +1,11 @@
+(library
+ ((name        qcow)
+  (public_name qcow)
+  (libraries (astring cmdliner cstruct logs lwt mirage-block mirage-block-unix mirage-types-lwt ppx_sexp_conv ppx_tools ppx_type_conv))
+  (wrapped false)
+  (preprocess (pps (ppx_sexp_conv)))))
+
+(rule
+ ((targets (qcow_word_size.ml))
+  (deps    (../generator/gen.exe))
+  (action  (run ${<} -o ${@}))))

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,0 +1,16 @@
+(executables
+ ((names (test compact_random))
+  (libraries   (qcow io-page.unix logs logs.fmt oUnit ezjsonm nbd.lwt mirage-block-ramdisk))
+  (preprocess (pps (ppx_sexp_conv)))
+))
+(alias
+ ((name runtest)
+  (deps (test.exe))
+  (action (run ${<} -runner sequential))
+))
+
+(alias
+ ((name runtest)
+  (deps (compact_random.exe))
+  (action (run ${<} -compact-mid-write -stop-after 16 ))
+))

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -6,7 +6,7 @@
 (alias
  ((name runtest)
   (deps (test.exe))
-  (action (run ${<} -runner sequential))
+  (action (run ${<} -runner sequential -verbose true))
 ))
 
 (alias

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -3,14 +3,3 @@
   (libraries   (qcow io-page.unix logs logs.fmt oUnit ezjsonm nbd.lwt mirage-block-ramdisk))
   (preprocess (pps (ppx_sexp_conv)))
 ))
-(alias
- ((name runtest)
-  (deps (test.exe))
-  (action (run ${<} -runner sequential -verbose true))
-))
-
-(alias
- ((name runtest)
-  (deps (compact_random.exe))
-  (action (run ${<} -compact-mid-write -stop-after 16 ))
-))

--- a/qcow-tool.opam
+++ b/qcow-tool.opam
@@ -40,7 +40,7 @@ build: [
 ]
 
 build-test: [
-  [ "jbuilder" "runtest" ]
+  [ make "test" ]
 ]
 
 available: [ocaml-version >= "4.03.0"]

--- a/qcow-tool.opam
+++ b/qcow-tool.opam
@@ -10,7 +10,8 @@ tags: [
 ]
 
 depends: [
-  "astring"
+  "qcow"
+  "cmdliner"
   "cstruct"
   "result"
   "mirage-types-lwt" {>= "3.0.0"}
@@ -20,16 +21,14 @@ depends: [
   "mirage-block-unix" {>= "2.1.0"}
   "mirage-time"
   "mirage-time-lwt"
-  "cmdliner"
+  "sha"
   "sexplib"
   "logs"
   "fmt"
+  "astring"
   "io-page"
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}
   "ezjsonm" {test}
@@ -37,7 +36,7 @@ depends: [
 ]
 
 build: [
-  [ "jbuilder" "build" "--only-packages=qcow" ]
+  [ "jbuilder" "build" ]
 ]
 
 build-test: [

--- a/qcow.opam
+++ b/qcow.opam
@@ -40,11 +40,11 @@ depends: [
 ]
 
 build: [
-  [ "ocaml" "detect_word_size.ml" ]
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+  [ "jbuilder" "build" ]
 ]
+
 build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
+  [ "jbuilder" "runtest" ]
 ]
+
 available: [ocaml-version >= "4.03.0"]

--- a/qcow.opam
+++ b/qcow.opam
@@ -41,7 +41,7 @@ build: [
 ]
 
 build-test: [
-  [ "jbuilder" "runtest" ]
+  [ make "test" ]
 ]
 
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
This is based on samoht/bew. To use:

    opam pin add jbuilder --dev
    make -f Makefile.experimental

Building everything with ocamlbuild takes ~9.4s
Building everything with jbuilder takes ~2.3s

Signed-off-by: David Scott <dave@recoil.org>