### PR TITLE
Decrement refcounts

### DIFF
--- a/_tags
+++ b/_tags
@@ -7,4 +7,4 @@ true: warn_error(+1..49-42), warn(A-3-4-41-44)
 
 <cli/**>: package(astring cmdliner io-page io-page.unix logs logs.fmt lwt mirage-block mirage-block-unix result sexplib)
 
-<lib_test/**>: package(astring ezjsonm mirage-block mirage-block-unix mirage-block-ramdisk oUnit ppx_sexp_conv nbd nbd.lwt)
+<lib_test/**>: package(astring ezjsonm logs logs.fmt mirage-block mirage-block-unix mirage-block-ramdisk oUnit ppx_sexp_conv nbd nbd.lwt)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1240,6 +1240,11 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: V1_LWT.TIME) = struct
     end
 
   let discard t ~sector ~n () =
+    ( if not(t.config.Config.discard) then begin
+        Log.err (fun f -> f "discard called but feature not implemented in configuration");
+        Lwt.return (`Error `Unimplemented)
+      end else Lwt.return (`Ok ()) )
+    >>*= fun () ->
     Timer.cancel t.background_compact_timer;
     Qcow_rwlock.with_read_lock t.metadata_lock
       (fun () ->

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -41,7 +41,8 @@ let random_write_discard_compact nr_clusters stop_after =
     let open FromBlock in
     Block.connect path
     >>= fun block ->
-    B.create block ~size ()
+    let config = B.Config.create ~discard:true () in
+    B.create block ~size ~lazy_refcounts:false ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
     B.get_info qcow

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -215,6 +215,7 @@ let random_write_discard_compact nr_clusters stop_after =
   or_failwith @@ Lwt_main.run t
 
 let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
   let clusters = ref 128 in
   let stop_after = ref 1024 in
   Arg.parse [

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -230,7 +230,8 @@ let write_discard_read_native sector_size size_sectors (start, length) () =
     let open FromBlock in
     RawWriter.connect path
     >>= fun raw ->
-    Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ()
+    let config = Writer.Config.create ~discard:true () in
+    Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ~config ()
     >>= fun b ->
 
     let sector = Int64.div start 512L in
@@ -519,7 +520,8 @@ let create_write_discard_all_compact clusters () =
     let open FromBlock in
     Block.connect path
     >>= fun block ->
-    B.create block ~size ()
+    let config = B.Config.create ~discard:true () in
+    B.create block ~size ~config ()
     >>= fun qcow ->
     let h = B.header qcow in
     let cluster_size = 1 lsl (Int32.to_int h.Qcow.Header.cluster_bits) in
@@ -567,7 +569,8 @@ let create_write_discard_compact () =
     let open FromBlock in
     Block.connect path
     >>= fun block ->
-    B.create block ~size ()
+    let config = B.Config.create ~discard:true () in
+    B.create block ~size ~config ()
     >>= fun qcow ->
     (* write a bunch of clusters at the beginning *)
     let h = B.header qcow in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -710,6 +710,7 @@ let qcow_tool_suite =
   create @ ok_resize @ bad_resize @ ignore_data_loss_resize @ create_resize_equals_create
 
 let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
   let sector_size = 512 in
   (* Test with a 1 PiB disk, bigger than we'll need for a while. *)
   let size_sectors = Int64.div pib 512L in


### PR DESCRIPTION
This PR avoids the clash between refcounts and TRIM/discard/compact by forcibly disabling refcounts when the `discard` configuration option is requested.

- if `discard` is requested, enable `lazy_refcounts` and zero existing refcounts
- if `discard` is performed but the `discard` feature is turned off, return an error

Fixes #56