### PR TITLE
Keep the interval tree balanced

### DIFF
--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -14,7 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-(* #require "ppx_sexp_conv";; *)
+(*
+#require "ppx_sexp_conv";;
+#require "lwt";;
+*)
 open Sexplib.Std
 
 module type ELT = sig


### PR DESCRIPTION
Previously some usage patterns could result in extremely unbalanced interval trees, making operations like `mem` linear in the number of intervals. This PR keeps the tree balanced so these worst case operations go from `linear` to `log_2`.