### PR TITLE
Misc fixes

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -868,6 +868,7 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
       )
 
   exception Reference_outside_file of int64 * int64
+  exception Duplicate_reference of int64 * int64 * int64
 
   let make_cluster_map t =
     let open Qcow_cluster_map in
@@ -926,8 +927,10 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
           let c', w' = Cluster.Map.find cluster !refs in
           Log.err (fun f -> f "Found two references to cluster %s: %s.%d and %s.%d"
             (Cluster.to_string cluster) (Cluster.to_string c) w (Cluster.to_string c') w');
-          failwith (Printf.sprintf "Found two references to cluster %s: %s.%d and %s.%d"
-            (Cluster.to_string cluster) (Cluster.to_string c) w (Cluster.to_string c') w');
+          let ref1 = Int64.add (Int64.of_int w) (Cluster.to_int64 c <| (Int32.to_int t.h.Header.cluster_bits)) in
+          let ref2 = Int64.add (Int64.of_int w') (Cluster.to_int64 c' <| (Int32.to_int t.h.Header.cluster_bits)) in
+          let dst = Cluster.to_int64 cluster <| (Int32.to_int t.h.Header.cluster_bits) in
+          raise (Duplicate_reference(ref1, ref2, dst))
         end;
         Qcow_bitmap.(remove (Interval.make (Cluster.to_int64 cluster) (Cluster.to_int64 cluster)) free);
         refs := Cluster.Map.add cluster rf !refs;
@@ -1356,6 +1359,7 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
         Lwt.return (Ok { free; used })
       ) (function
         | Reference_outside_file(src, dst) -> Lwt.return (Error (`Reference_outside_file(src, dst)))
+        | Duplicate_reference(ref1, ref2, dst) -> Lwt.return (Error (`Duplicate_reference(ref1, ref2, dst)))
         | e -> Lwt.fail e)
 
   let resize t ~new_size:requested_size_bytes ?(ignore_data_loss=false) () =

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1343,19 +1343,14 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
 
   let check base =
     let open Lwt.Infix in
-    connect base
-    >>= fun t ->
+
     let open Qcow_cluster_map in
     Lwt.catch
       (fun () ->
-        make_cluster_map t
-        >>= function
-        | Error `Disconnected -> Lwt.return (Error `Disconnected)
-        | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
-        | Error (`Msg m) -> Lwt.return (Error (`Msg m))
-        | Ok block_map ->
-        let free = total_free block_map in
-        let used = total_used block_map in
+        connect base
+        >>= fun t ->
+        let free = total_free t.cluster_map in
+        let used = total_used t.cluster_map in
         Lwt.return (Ok { free; used })
       ) (function
         | Reference_outside_file(src, dst) -> Lwt.return (Error (`Reference_outside_file(src, dst)))

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -113,11 +113,14 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
   val check: B.t -> (check_result, [
     Mirage_block.error
     | `Reference_outside_file of int64 * int64
+    | `Duplicate_reference of int64 * int64 * int64
     | `Msg of string
   ]) result io
   (** [check t] performs sanity checks of the file, looking for errors.
       The error [`Reference_outside_file (src, dst)] means that at offset [src]
-      there is a reference to offset [dst] which is outside the file. *)
+      there is a reference to offset [dst] which is outside the file.
+      The error [`Duplicate_reference (ref1, ref2, target) means that references
+      at both [ref1] and [ref2] both point to the same [target] offset. *)
 
   val header: t -> Header.t
   (** Return a snapshot of the current header *)

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -223,13 +223,13 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                   let dst = Cluster.to_int dst lsl t.cluster_bits in
                   let new_reference = Qcow_physical.make ~is_mutable:(Qcow_physical.is_mutable old_reference) ~is_compressed:(Qcow_physical.is_compressed old_reference) dst in
                   Metadata.Physical.set addresses ref_cluster_within new_reference;
+                  nr_updated := Int64.succ !nr_updated;
                   Lwt.return (Ok ())
                 end
               )
         >>= function
         | Ok () ->
           set_move_state cluster_map move.move Referenced;
-          nr_updated := Int64.add !nr_updated (Int64.of_int (List.length flushed));
           Lwt.return (Ok ())
         | Error e -> Lwt.return (Error e)
       ) flushed


### PR DESCRIPTION
- catch the exception properly in `check` (previously it would escape to the top-level)
- ensure `compact` runs enough iterations (2 may be needed, 3 is a sanity-check)
- fix the calculation of the number of updated blocks