### PR TITLE
Trim/discard fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,27 +1,27 @@
-0.9.0 (2017-02-21)
+## 0.9.0 (2017-02-21)
 - Add online coalescing mode and background cluster recycling thread
 - Rename internal modules and types
 - Ensure the interval tree remains balanced to improve performance
 
-0.8.1 (2017-02-13)
+## 0.8.1 (2017-02-13)
 - fix error in META file
 
-0.8.0 (2017-02-13)
+## 0.8.0 (2017-02-13)
 - update to Mirage 3 APIs
 - now requires OCaml 4.03+
 - ensure the interval tree is kept balanced
 
-0.7.2 (2016-12-21)
+## 0.7.2 (2016-12-21)
 - if `discard` is not enabled, fail `discard` calls
 - if `discard` is enabled, enable lazy-refcounts and zero refcount clusters
   to avoid breaking refcounts over `discard`, `compact`
 
-0.7.1 (2016-12-15)
+## 0.7.1 (2016-12-15)
 - speed up `check` and `compact` up to 50x
 - `qcow-tool compact` work around files which aren't a whole number of
   sectors
 
-0.7.0 (2016-12-10)
+## 0.7.0 (2016-12-10)
 - now functorised over `TIME`
 - allow background compact to be cancelled
 - cancel background compact to allow regular I/O to go through
@@ -29,40 +29,40 @@
   `discard`
 - on `connect`, sanity-check the image
 
-0.6.0 (2016-12-04)
+## 0.6.0 (2016-12-04)
 - rename ocamlfind package from `qcow-format` to `qcow` for uniformity
 - add support for runtime configuration arguments to `connect` and `create`
 - add support for `discard` (aka TRIM or UNMAP) and online compaction
   (through a stop-the-world GC)
 - switch the build from `oasis` to `topkg` (thanks to @jgimenez)
 
-0.5.0 (2016-11-26)
+## 0.5.0 (2016-11-26)
 - `resize` now takes a new size in bytes (rather than sectors) and uses a
   labelled argument
 - `qcow-tool info` now takes a `--filter <expression>` for example
   `qcow-tool info ... --filter .size` to view the virtual size
 
-0.4.2 (2016-09-21)
+## 0.4.2 (2016-09-21)
 - Don't break the build if `Block.connect` has optional arguments
 
-0.4.1 (2016-08-17)
+## 0.4.1 (2016-08-17)
 - Remove one necessary source of `flush` calls
 - CLI: add `mapped` command to list the mapped regions of a file
 
-0.4 (2016-08-03)
+## 0.4 (2016-08-03)
 - For buffered block devices, call `flush` to guarantee metadata correctness
 - In lazy_refcounts mode (the default), do not compute any refcounts
 - CLI: the `repair` command should recompute refcounts
 
-0.3 (2016-05-12)
+## 0.3 (2016-05-12)
 - Depend on ppx, require OCaml 4.02+
 
-0.2 (2016-01-15)
+## 0.2 (2016-01-15)
 - Use qcow version 3 by default, setting `lazy_refcount=on`
 - Unit tests now verify that `qemu-img check` is happy and that `qemu-nbd`
   sees the same data we wrote
 
-0.1 (2015-11-09)
+## 0.1 (2015-11-09)
 - initial `V1_LWT.BLOCK` support
 - caches metadata for performance
 - CLI tool for manipulating images

--- a/_tags
+++ b/_tags
@@ -7,4 +7,4 @@ true: warn_error(+1..49-42), warn(A-3-4-41-44)
 
 <cli/**>: package(astring cmdliner io-page io-page.unix logs logs.fmt lwt mirage-time mirage-time-lwt mirage-block mirage-block-lwt mirage-block-unix result sexplib sha.sha1)
 
-<lib_test/**>: package(astring ezjsonm logs logs.fmt mirage-time mirage-time-lwt mirage-block mirage-block-lwt  mirage-block-unix mirage-block-ramdisk oUnit ppx_sexp_conv nbd nbd.lwt)
+<lib_test/**>: package(astring ezjsonm logs logs.fmt fmt mirage-time mirage-time-lwt mirage-block mirage-block-lwt  mirage-block-unix mirage-block-ramdisk oUnit ppx_sexp_conv nbd nbd.lwt)

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -862,8 +862,6 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     B.get_info t.base
     >>= fun base_info ->
     let max_cluster = Cluster.of_int64 @@ Int64.div base_info.Mirage_block.size_sectors sectors_per_cluster in
-    let next_cluster = Cluster.succ max_cluster in
-
     (* Iterate over the all clusters referenced from all the tables in the file
        and (a) construct a set of free clusters; and (b) construct a map of
        physical cluster back to virtual. The free set will show us the holes,

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -122,6 +122,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
       The error [`Duplicate_reference (ref1, ref2, target) means that references
       at both [ref1] and [ref2] both point to the same [target] offset. *)
 
+  val flush : t -> (unit, write_error) result io
+  (** [flush t] flushes any outstanding buffered writes *)
+
   val header: t -> Header.t
   (** Return a snapshot of the current header *)
 

--- a/lib/qcow_cache.ml
+++ b/lib/qcow_cache.ml
@@ -48,6 +48,10 @@ let read t cluster =
   end
 
 let write t cluster data =
+  if not (Cluster.Map.mem cluster t.clusters) then begin
+    Log.err (fun f -> f "Cache.write %s: cluster is nolonger in cache, so update will be dropped" (Cluster.to_string cluster));
+    assert false
+  end;
   t.clusters <- Cluster.Map.add cluster data t.clusters;
   t.write_cluster cluster data
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -242,7 +242,7 @@ let get_last_block t =
       Cluster.IntervalSet.Interval.y @@ Cluster.IntervalSet.max_elt t.roots
     with Not_found ->
       max_ref in
-  max max_ref max_root
+  max (Cluster.pred t.first_movable_cluster) @@ max max_ref max_root
 
 let to_summary_string t =
   let copying, copied, flushed, referenced = total_moves t in

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -35,12 +35,25 @@ type move_state =
 
 module Move = struct
   type t = { src: Cluster.t; dst: Cluster.t }
+
+  let to_string t =
+    Printf.sprintf "%s -> %s" (Cluster.to_string t.src) (Cluster.to_string t.dst)
 end
 
 type move = {
   move: Move.t;
   state: move_state;
 }
+
+let string_of_move m =
+  let state = match m.state with
+    | Copying    -> "Copying"
+    | Copied     -> "Copied"
+    | Flushed    -> "Flushed"
+    | Referenced -> "Referenced" in
+  Printf.sprintf "%s %s"
+    (Move.to_string m.move)
+    state
 
 type t = {
   mutable junk: Cluster.IntervalSet.t;

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -296,10 +296,15 @@ let get_moves t =
         let last_block, rf = Cluster.Map.max_binding (!refs) in
 
         if cluster >= last_block then moves, last_block else begin
-          (* copy last_block into cluster and update rf *)
-          let move = { Move.src = last_block; dst = cluster } in
-          refs := Cluster.Map.remove last_block @@ Cluster.Map.add cluster rf (!refs);
-          move :: moves, last_block
+          let src = last_block and dst = cluster in
+          if Cluster.Map.mem src t.moves
+          then moves, last_block (* move already in progress, don't move it again *)
+          else begin
+            (* copy last_block into cluster and update rf *)
+            let move = { Move.src; dst } in
+            refs := Cluster.Map.remove last_block @@ Cluster.Map.add cluster rf (!refs);
+            move :: moves, last_block
+          end
         end
       end
     ) t.junk ([], max_cluster)

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -43,6 +43,8 @@ type reference = Cluster.t * int (* cluster * index within cluster *)
 module Move: sig
   type t = { src: Cluster.t; dst: Cluster.t }
   (** An instruction to move the contents from cluster [src] to cluster [dst] *)
+
+  val to_string: t -> string
 end
 
 type move = {
@@ -50,6 +52,8 @@ type move = {
   state: move_state;
 }
 (** describes the state of an in-progress block move *)
+
+val string_of_move: move -> string
 
 module type MutableSet = sig
   val get: t -> Cluster.IntervalSet.t

--- a/lib/qcow_metadata.ml
+++ b/lib/qcow_metadata.ml
@@ -78,8 +78,6 @@ module Physical = struct
                       (if cluster <> Cluster.zero then ", unmapping " ^ (Cluster.to_string cluster) else "")
                   );
         if cluster <> Cluster.zero then begin
-          let i = Cluster.IntervalSet.(add (Interval.make cluster cluster) empty) in
-          Qcow_cluster_map.Junk.add m i;
           Qcow_cluster_map.remove m cluster;
         end;
         Qcow_cluster_map.add m (t.cluster, n) v'

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -218,11 +218,13 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                     let new_reference = Qcow_physical.make ~is_mutable:(Qcow_physical.is_mutable old_reference) ~is_compressed:(Qcow_physical.is_compressed old_reference) dst in
                     Metadata.Physical.set addresses ref_cluster_within new_reference;
                     nr_updated := Int64.succ !nr_updated;
+                    set_move_state cluster_map move.move Referenced;
+                    (* The move cannot be cancelled now that the metadata has
+                       been updated. *)
                     Lwt.return (Ok ())
                   end
                 ) >>= function
                 | Ok () ->
-                  set_move_state cluster_map move.move Referenced;
                   Lwt.return (Ok ())
                 | Error e -> Lwt.return (Error e)
             end

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -247,7 +247,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     (* Anything erased right now will become available *)
     let erased = Qcow_cluster_map.Erased.get cluster_map in
     let moves = Qcow_cluster_map.moves cluster_map in
-    Log.info (fun f -> f "block recycler: flush: %s" (Qcow_cluster_map.to_summary_string cluster_map));
     B.flush t.base
     >>= function
     | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
@@ -268,11 +267,13 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
           Qcow_cluster_map.complete_move cluster_map move.move;
           nr_flushed, nr_completed + 1, Cluster.IntervalSet.(add (Interval.make src src) junk)
         ) moves (0, 0, Cluster.IntervalSet.empty) in
-      let nr_erased = Cluster.IntervalSet.cardinal erased in
-      let nr_junk = Cluster.IntervalSet.cardinal junk in
-      if nr_flushed <> 0 || nr_completed <> 0
-      then Log.info (fun f -> f "block recycler: %d cluster copies flushed; %d cluster copies complete; %s clusters erased; %s junk clusters created"
-        nr_flushed nr_completed (Cluster.to_string nr_erased) (Cluster.to_string nr_junk));
+      let nr_erased = Cluster.to_int @@ Cluster.IntervalSet.cardinal erased in
+      let nr_junk = Cluster.to_int @@ Cluster.IntervalSet.cardinal junk in
+      if nr_flushed <> 0 || nr_completed <> 0 || nr_erased <> 0 || nr_junk <> 0 then begin
+        Log.info (fun f -> f "block recycler: %d cluster copies flushed; %d cluster copies complete; %d clusters erased; %d junk clusters created"
+          nr_flushed nr_completed nr_erased nr_junk);
+          Log.info (fun f -> f "block recycler: flush: %s" (Qcow_cluster_map.to_summary_string cluster_map));
+      end;
       Qcow_cluster_map.Junk.add cluster_map junk;
       Qcow_cluster_map.Available.add cluster_map erased;
       Qcow_cluster_map.Erased.remove cluster_map erased;

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -74,8 +74,6 @@ module type DEBUG = sig
   val check_no_overlaps: t -> (unit, error) result Lwt.t
 
   val assert_no_leaked_blocks: t -> unit
-
-  val flush: t -> (unit, error) result Lwt.t
 end
 
 module type INTERVAL_SET = sig

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -74,8 +74,6 @@ module type DEBUG = sig
   val check_no_overlaps: t -> (unit, error) result Lwt.t
 
   val assert_no_leaked_blocks: t -> unit
-
-  val flush: t -> (unit, error) result Lwt.t
 end
 
 module type INTERVAL_SET = sig

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -168,7 +168,7 @@ let random_write_discard_compact nr_clusters stop_after =
       B.Debug.assert_no_leaked_blocks qcow;
       if !nr_iterations = stop_after then Lwt.return (Ok ()) else begin
         (* Call flush so any erased blocks become reusable *)
-        B.Debug.flush qcow
+        B.flush qcow
         >>= function
         | Error _ -> failwith "flush"
         | Ok () ->


### PR DESCRIPTION
- fix a double-allocation bug
- use tail-recursive functions to avoid blowing up the stack
- avoid cancelling in-progress moves unnecessarily
- always try to resize the file to trim junk