### PR TITLE
Make the cluster locks recursive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: required
 dist: trusty
 env:
   global:
-    - EXTRA_REMOTES="https://github.com/mirage/mirageos-3-beta.git"
     - PACKAGE="qcow-format" OCAML_VERSION=4.03
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,21 @@
+## 0.9.1 (2017-02-25)
+- Add configuration `runtime_assert` to check GC invariants at runtime
+- Use tail-recursive calls in the block recycler (which deals with large
+  block lists)
+- Wait for the compaction work list to stabilise before processing it
+  (otherwise we move blocks which are then immediately discarded)
+- Track the difference between blocks on the end of the file being full
+  of zeroes due to ftruncate versus being full of junk due to discard
+- On open, truncate the file to erase trailing junk
+- Don't try to use free space between header structures for user data
+  since we assume all blocks after the start of free space are movable
+  and header blocks aren't (in this implementation)
+- Make cluster locks recursive, hold relevant metadata read locks while
+  reading or writing data clusters to ensure they aren't moved while
+  we're using them.
+- Add a debug testing mode and use it in a test case to verify that
+  compact mid-write works as expected.
+
 ## 0.9.0 (2017-02-21)
 - Add online coalescing mode and background cluster recycling thread
 - Rename internal modules and types

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -962,7 +962,8 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     l1_iter 0L
     >>= fun () ->
 
-    let map = make ~free ~refs:(!refs) ~first_movable_cluster ~cache:t.cache in
+    let map = make ~free ~refs:(!refs) ~first_movable_cluster ~cache:t.cache
+      ~runtime_asserts:t.config.Config.runtime_asserts in
 
     Lwt.return (Ok map)
 

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -26,7 +26,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
       discard: bool; (** true if `discard` will be enabled at runtime *)
       keep_erased: int64 option; (** size of erased free pool in sectors *)
       compact_after_unmaps: int64 option; (** automatically compact after n sectors are unmapped *)
-      compact_ms: int; (** if automatically compacting, wait for this many milliseconds *)
       check_on_connect: bool; (** perform an integrity check on connect *)
       runtime_asserts: bool; (** check cluster invariants at runtime *)
     }
@@ -35,7 +34,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
     val create: ?discard:bool ->
       ?keep_erased:int64 ->
       ?compact_after_unmaps:int64 ->
-      ?compact_ms:int ->
       ?check_on_connect:bool ->
       ?runtime_asserts:bool -> unit -> t
     (** Customise the runtime behaviour, see [connect] or [create] *)

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -28,14 +28,17 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
       compact_after_unmaps: int64 option; (** automatically compact after n sectors are unmapped *)
       compact_ms: int; (** if automatically compacting, wait for this many milliseconds *)
       check_on_connect: bool; (** perform an integrity check on connect *)
+      runtime_asserts: bool; (** check cluster invariants at runtime *)
     }
     (** Runtime configuration of a device *)
 
     val create: ?discard:bool ->
       ?keep_erased:int64 ->
       ?compact_after_unmaps:int64 ->
-      ?compact_ms:int -> ?check_on_connect:bool -> unit -> t
-    (** [create ?discard ?keep_erased ?compact_after_unmaps ?compact_ms ()] constructs a runtime configuration *)
+      ?compact_ms:int ->
+      ?check_on_connect:bool ->
+      ?runtime_asserts:bool -> unit -> t
+    (** Customise the runtime behaviour, see [connect] or [create] *)
 
     val to_string: t -> string
     (** Marshal a config into a string suitable for a command-line argument *)

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -145,9 +145,9 @@ module Debug = struct
       let all = [ junk; erased; available; refs; moves; roots ] in
       let leaked = List.fold_left diff whole_file (List.map snd all) in
       if leaks && (cardinal leaked <> Cluster.zero) then begin
-        Printf.fprintf stderr "%s\n" (to_summary_string t);
-        Printf.fprintf stderr "%s clusters leaked: %s" (Cluster.to_string @@ cardinal leaked)
-          (Sexplib.Sexp.to_string_hum (sexp_of_t leaked));
+        Log.err (fun f -> f "%s" (to_summary_string t));
+        Log.err (fun f -> f "%s clusters leaked: %s" (Cluster.to_string @@ cardinal leaked)
+          (Sexplib.Sexp.to_string_hum (sexp_of_t leaked)));
         assert false
       end;
       let rec cross xs = function
@@ -158,11 +158,11 @@ module Debug = struct
           if x_name <> y_name then begin
             let i = inter x y in
             if cardinal i <> Cluster.zero then begin
-              Printf.fprintf stderr "%s\n" (to_summary_string t);
-              Printf.fprintf stderr "%s and %s are not disjoint\n" x_name y_name;
-              Printf.fprintf stderr "%s = %s\n" x_name (Sexplib.Sexp.to_string_hum (sexp_of_t x));
-              Printf.fprintf stderr "%s = %s\n" y_name (Sexplib.Sexp.to_string_hum (sexp_of_t y));
-              Printf.fprintf stderr "intersection = %s\n" (Sexplib.Sexp.to_string_hum (sexp_of_t i));
+              Log.err (fun f -> f "%s" (to_summary_string t));
+              Log.err (fun f -> f "%s and %s are not disjoint" x_name y_name);
+              Log.err (fun f -> f "%s = %s" x_name (Sexplib.Sexp.to_string_hum (sexp_of_t x)));
+              Log.err (fun f -> f "%s = %s" y_name (Sexplib.Sexp.to_string_hum (sexp_of_t y)));
+              Log.err (fun f -> f "intersection = %s" (Sexplib.Sexp.to_string_hum (sexp_of_t i)));
               assert false
             end
           end

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -129,11 +129,6 @@ val with_roots: t -> Cluster.IntervalSet.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
 val get_moves: t -> Move.t list
 (** [get_moves t] calculates the block moves required to compact [t] *)
 
-val compact_s: (Move.t -> 'a -> ((bool * 'a), 'b) result Lwt.t ) -> t -> 'a
-  -> ('a, 'b) result Lwt.t
-(** [compact_s f t acc] accumulates the result of [f move] where [move] is
-    the next cluster move needed to perform a compaction of [t].. *)
-
 val get_last_block: t -> Cluster.t
 (** [get_last_block t] is the last allocated block in [t]. Note if there are no
     data blocks this will point to the last header block even though it is

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -70,7 +70,7 @@ val zero: t
 (** A cluster map for a zero-length disk *)
 
 val make: free:Qcow_bitmap.t -> refs:reference Cluster.Map.t -> cache:Qcow_cache.t
-  -> first_movable_cluster:Cluster.t -> t
+  -> first_movable_cluster:Cluster.t -> runtime_asserts:bool -> t
 (** Given a set of free clusters, and the first cluster which can be moved
     (i.e. that isn't fixed header), construct an empty cluster map. *)
 

--- a/lib/qcow_config.ml
+++ b/lib/qcow_config.ml
@@ -19,18 +19,17 @@ type t = {
   discard: bool;
   keep_erased: int64 option;
   compact_after_unmaps: int64 option;
-  compact_ms: int;
   check_on_connect: bool;
   runtime_asserts: bool;
 }
-let create ?(discard=false) ?keep_erased ?compact_after_unmaps ?(compact_ms=1000) ?(check_on_connect=true) ?(runtime_asserts=false) () =
-  { discard; keep_erased; compact_after_unmaps; compact_ms; check_on_connect; runtime_asserts }
-let to_string t = Printf.sprintf "discard=%b;keep_erased=%scompact_after_unmaps=%s;compact_ms=%d;check_on_connect=%b;runtime_asserts=%b"
+let create ?(discard=false) ?keep_erased ?compact_after_unmaps ?(check_on_connect=true) ?(runtime_asserts=false) () =
+  { discard; keep_erased; compact_after_unmaps; check_on_connect; runtime_asserts }
+let to_string t = Printf.sprintf "discard=%b;keep_erased=%scompact_after_unmaps=%s;check_on_connect=%b;runtime_asserts=%b"
     t.discard
     (match t.keep_erased with None -> "0" | Some x -> Int64.to_string x)
     (match t.compact_after_unmaps with None -> "0" | Some x -> Int64.to_string x)
-    t.compact_ms t.check_on_connect t.runtime_asserts
-let default = { discard = false; keep_erased = None; compact_after_unmaps = None; compact_ms = 1000; check_on_connect = true; runtime_asserts = false }
+    t.check_on_connect t.runtime_asserts
+let default = { discard = false; keep_erased = None; compact_after_unmaps = None; check_on_connect = true; runtime_asserts = false }
 let of_string txt =
   let open Astring in
   try
@@ -47,7 +46,6 @@ let of_string txt =
             | "compact_after_unmaps" ->
               let compact_after_unmaps = if v = "0" then None else Some (Int64.of_string v) in
               { t with compact_after_unmaps }
-            | "compact_ms" -> { t with compact_ms = int_of_string v }
             | "check_on_connect" -> { t with check_on_connect = bool_of_string v }
             | "runtime_asserts" -> { t with runtime_asserts = bool_of_string v }
             | x -> failwith ("Unknown qcow configuration key: " ^ x)

--- a/lib/qcow_config.ml
+++ b/lib/qcow_config.ml
@@ -21,15 +21,16 @@ type t = {
   compact_after_unmaps: int64 option;
   compact_ms: int;
   check_on_connect: bool;
+  runtime_asserts: bool;
 }
-let create ?(discard=false) ?keep_erased ?compact_after_unmaps ?(compact_ms=1000) ?(check_on_connect=true) () =
-  { discard; keep_erased; compact_after_unmaps; compact_ms; check_on_connect }
-let to_string t = Printf.sprintf "discard=%b;keep_erased=%scompact_after_unmaps=%s;compact_ms=%d;check_on_connect=%b"
+let create ?(discard=false) ?keep_erased ?compact_after_unmaps ?(compact_ms=1000) ?(check_on_connect=true) ?(runtime_asserts=false) () =
+  { discard; keep_erased; compact_after_unmaps; compact_ms; check_on_connect; runtime_asserts }
+let to_string t = Printf.sprintf "discard=%b;keep_erased=%scompact_after_unmaps=%s;compact_ms=%d;check_on_connect=%b;runtime_asserts=%b"
     t.discard
     (match t.keep_erased with None -> "0" | Some x -> Int64.to_string x)
     (match t.compact_after_unmaps with None -> "0" | Some x -> Int64.to_string x)
-    t.compact_ms t.check_on_connect
-let default = { discard = false; keep_erased = None; compact_after_unmaps = None; compact_ms = 1000; check_on_connect = true }
+    t.compact_ms t.check_on_connect t.runtime_asserts
+let default = { discard = false; keep_erased = None; compact_after_unmaps = None; compact_ms = 1000; check_on_connect = true; runtime_asserts = false }
 let of_string txt =
   let open Astring in
   try
@@ -48,6 +49,7 @@ let of_string txt =
               { t with compact_after_unmaps }
             | "compact_ms" -> { t with compact_ms = int_of_string v }
             | "check_on_connect" -> { t with check_on_connect = bool_of_string v }
+            | "runtime_asserts" -> { t with runtime_asserts = bool_of_string v }
             | x -> failwith ("Unknown qcow configuration key: " ^ x)
           end
       ) default strings)

--- a/lib/qcow_config.mli
+++ b/lib/qcow_config.mli
@@ -25,10 +25,6 @@ type t = {
   compact_after_unmaps: int64 option;
   (** once more than this many sectors are free, perform a compact *)
 
-  compact_ms: int;
-  (** if compact_after_unmaps is set, wait for this many ms before starting
-      the compact *)
-
   check_on_connect: bool;
   (** perform an integrity check on connect *)
 
@@ -37,7 +33,7 @@ type t = {
 }
 
 val create: ?discard:bool -> ?keep_erased:int64 ->
-  ?compact_after_unmaps:int64 -> ?compact_ms:int -> ?check_on_connect:bool ->
+  ?compact_after_unmaps:int64 -> ?check_on_connect:bool ->
   ?runtime_asserts:bool ->
   unit -> t
 

--- a/lib/qcow_config.mli
+++ b/lib/qcow_config.mli
@@ -31,10 +31,14 @@ type t = {
 
   check_on_connect: bool;
   (** perform an integrity check on connect *)
+
+  runtime_asserts: bool;
+  (** constantly verify GC invariants are held *)
 }
 
 val create: ?discard:bool -> ?keep_erased:int64 ->
   ?compact_after_unmaps:int64 -> ?compact_ms:int -> ?check_on_connect:bool ->
+  ?runtime_asserts:bool ->
   unit -> t
 
 val default: t

--- a/lib/qcow_locks.ml
+++ b/lib/qcow_locks.ml
@@ -22,6 +22,8 @@ type t = {
   (** held during metadata changing operations *)
 }
 
+module Client = Qcow_rwlock.Client
+
 let make () =
   let locks = Cluster.Map.empty in
   let metadata_m = Lwt_mutex.create () in
@@ -34,7 +36,7 @@ let get_lock t cluster =
     if Cluster.Map.mem cluster t.locks
     then Cluster.Map.find cluster t.locks
     else begin
-      Qcow_rwlock.make (), 0
+      Qcow_rwlock.make (fun () -> Printf.sprintf "cluster %s" (Cluster.to_string cluster)), 0
     end in
   t.locks <- Cluster.Map.add cluster (lock, refcount + 1) t.locks;
   lock
@@ -48,42 +50,75 @@ let put_lock t cluster =
     then Cluster.Map.remove cluster t.locks
     else Cluster.Map.add cluster (lock, refcount - 1) t.locks
 
-let with_lock t cluster f =
+let with_rwlock t cluster f =
   let lock = get_lock t cluster in
   Lwt.finalize (fun () -> f lock) (fun () -> put_lock t cluster; Lwt.return_unit)
 
-let with_read_lock t cluster f =
-  with_lock t cluster
-    (fun rw ->
-      Qcow_rwlock.with_read_lock rw f
-    )
+type lock = {
+  lock: Qcow_rwlock.lock;
+  t: t;
+  cluster: Cluster.t;
+}
 
-let with_read_locks t ~first ~last f =
-  let rec loop n =
-    if n > last
-    then f ()
-    else
-      with_lock t n
-        (fun rw ->
-          Qcow_rwlock.with_read_lock rw
-            (fun () -> loop (Cluster.succ n))
-        ) in
-  loop first
+let unlock lock =
+  Qcow_rwlock.unlock lock.lock;
+  put_lock lock.t lock.cluster
 
-let with_write_lock t cluster f =
-  with_lock t cluster
-    (fun rw ->
-      Qcow_rwlock.with_read_lock rw f
-    )
+module Read = struct
+  let with_lock ?client t cluster f =
+    with_rwlock t cluster
+      (fun rw ->
+        Qcow_rwlock.Read.with_lock ?client rw f
+      )
 
-let with_write_locks t ~first ~last f =
-  let rec loop n =
-    if n > last
-    then f ()
-    else
-      with_lock t n
-        (fun rw ->
-          Qcow_rwlock.with_write_lock rw
-            (fun () -> loop (Cluster.succ n))
-        ) in
-  loop first
+  let with_locks ?client t ~first ~last f =
+    let rec loop n =
+      if n > last
+      then f ()
+      else
+        with_rwlock t n
+          (fun rw ->
+            Qcow_rwlock.Read.with_lock ?client rw
+              (fun () -> loop (Cluster.succ n))
+          ) in
+    loop first
+
+  let lock ?client t cluster =
+    let lock = get_lock t cluster in
+    let open Lwt.Infix in
+    Qcow_rwlock.Read.lock ?client lock
+    >>= fun lock ->
+    Lwt.return { lock; t; cluster }
+end
+
+module Write = struct
+  let with_lock ?client t cluster f =
+    with_rwlock t cluster
+      (fun rw ->
+        Qcow_rwlock.Write.with_lock ?client rw f
+      )
+
+  let with_locks ?client t ~first ~last f =
+    let rec loop n =
+      if n > last
+      then f ()
+      else
+        with_rwlock t n
+          (fun rw ->
+            Qcow_rwlock.Write.with_lock ?client rw
+              (fun () -> loop (Cluster.succ n))
+          ) in
+    loop first
+
+  let try_lock ?client t cluster =
+    let lock = get_lock t cluster in
+    match Qcow_rwlock.Write.try_lock ?client lock with
+    | None ->
+      put_lock t cluster;
+      None
+    | Some lock ->
+      let lock = { lock; t; cluster } in
+      Some lock
+end
+
+module Debug = Qcow_rwlock.Debug

--- a/lib/qcow_locks.mli
+++ b/lib/qcow_locks.mli
@@ -22,20 +22,59 @@ type t
 val make: unit -> t
 (** Create a set of locks *)
 
-val with_read_lock: t -> Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_read_lock t f] executes [f ()] with the lock held for reading *)
+type lock
+(** A value which represents holding a lock *)
 
-val with_read_locks: t -> first:Cluster.t -> last:Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_read_locks t ~first ~last f] executes [f ()] with all clusters in the
-    interval [first .. last] inclusive locked for reading. *)
+val unlock: lock -> unit
+(** [unlock lock] releases the lock. Note releasing the same lock more than
+    once will trigger a runtime failure. *)
 
-val with_write_lock: t -> Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_write_lock t f] executes [f ()] with the lock held for writing *)
+module Client: sig
+  type t
+  (** An entity which holds a set of locks *)
 
-val with_write_locks: t -> first:Cluster.t -> last:Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_write_locks t ~first ~last f] executes [f ()] with all clusters in the
-    interval [first .. last] inclusive locked for writing. *)
+  val make: (unit -> string) -> t
+  (** [make describe_fn] creates an entity where [describe_fn ()] returns
+      a human-readable description of the client for use in debugging. *)
+end
+
+module Read: sig
+  (** Non-exclusive read locks *)
+
+  val with_lock: ?client:Client.t -> t -> Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_lock t f] executes [f ()] with the lock held for reading *)
+
+  val with_locks: ?client:Client.t -> t -> first:Cluster.t -> last:Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_locks t ~first ~last f] executes [f ()] with all clusters in the
+      interval [first .. last] inclusive locked for reading. *)
+
+  val lock: ?client:Client.t -> t -> Cluster.t -> lock Lwt.t
+  (** [lock t cluster] acquire a non-exclusive read lock on [cluster]. The
+      resulting lock must be released by calling [unlock] *)
+
+end
+
+module Write: sig
+  (** Exclusive write locks *)
+
+  val with_lock: ?client:Client.t -> t -> Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_lock t f] executes [f ()] with the lock held for writing *)
+
+  val with_locks: ?client:Client.t -> t -> first:Cluster.t -> last:Cluster.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_locks t ~first ~last f] executes [f ()] with all clusters in the
+      interval [first .. last] inclusive locked for writing. *)
+
+  val try_lock: ?client:Client.t -> t -> Cluster.t -> lock option
+  (** [try_lock ?client t cluster] returns a write lock on [cluster] if it can
+      be done without blocking, or returns None. *)
+end
 
 val with_metadata_lock: t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
 (** [with_metadata_lock t f] executes [f ()] with the global metadata lock held.
     This prevents metadata blocks from moving while they're being used. *)
+
+module Debug: sig
+
+  val assert_no_locks_held: Client.t -> unit
+  (** Check that all locks have been explicitly released. *)
+end

--- a/lib/qcow_metadata.mli
+++ b/lib/qcow_metadata.mli
@@ -71,9 +71,11 @@ end
 val erase: contents -> unit
 (** Set the cluster contents to zeroes *)
 
-val read: t -> Cluster.t -> (contents -> ('a, error) result Lwt.t) -> ('a, error) result Lwt.t
+val read_and_lock: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents * Qcow_locks.lock, error) result Lwt.t
+
+val read: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents -> ('a, error) result Lwt.t) -> ('a, error) result Lwt.t
 (** Read the contents of the given cluster and provide them to the given function *)
 
-val update: t -> Cluster.t -> (contents -> (unit, write_error) result Lwt.t) -> (unit, write_error) result Lwt.t
+val update: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents -> (unit, write_error) result Lwt.t) -> (unit, write_error) result Lwt.t
 (** Read the contents of the given cluster, transform them through the given
     function and write the results back to disk *)

--- a/lib/qcow_recycler.mli
+++ b/lib/qcow_recycler.mli
@@ -43,8 +43,8 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S): sig
   val copy: t -> Cluster.t -> Cluster.t -> (unit, B.write_error) result Lwt.t
   (** [copy src dst] copies the cluster [src] to [dst] *)
 
-  val move: t -> Qcow_cluster_map.Move.t -> (unit, B.write_error) result Lwt.t
-  (** [move t mv] perform the initial data copy of the move operation [mv] *)
+  val move_all: t -> Qcow_cluster_map.Move.t list -> (unit, Qcow_metadata.write_error) result Lwt.t
+  (** [move_all t mv] perform the initial data copy of the move operations [mv] *)
 
   val update_references: t -> (int64, Qcow_metadata.write_error) result Lwt.t
   (** [update_references t] rewrites references to any recently copied and

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -74,6 +74,10 @@ module type DEBUG = sig
   val check_no_overlaps: t -> (unit, error) result Lwt.t
 
   val assert_no_leaked_blocks: t -> unit
+
+  module Setting: sig
+    val compact_mid_write: bool ref
+  end
 end
 
 module type INTERVAL_SET = sig

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -74,6 +74,12 @@ module type DEBUG = sig
   val check_no_overlaps: t -> (unit, error) result Lwt.t
 
   val assert_no_leaked_blocks: t -> unit
+
+  module Setting: sig
+    val compact_mid_write: bool ref
+    (** true means to trigger a compact part-way through a write to check that
+        the write completes properly after the compact *)
+  end
 end
 
 module type INTERVAL_SET = sig

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -159,12 +159,12 @@ let random_write_discard_compact nr_clusters stop_after =
           Lwt.return_unit in
       Lwt.pick [
         check (fun _ -> 0L) !empty;
-        Lwt_unix.sleep 5. >>= fun () -> Lwt.fail (Failure "check empty")
+        Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "check empty")
       ]
       >>= fun () ->
       Lwt.pick [
         check (fun x -> x) !written;
-        Lwt_unix.sleep 5. >>= fun () -> Lwt.fail (Failure "check written")
+        Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "check written")
       ] in
     Random.init 0;
     let rec loop () =
@@ -185,7 +185,7 @@ let random_write_discard_compact nr_clusters stop_after =
             Printf.printf ".%!";
             Lwt.pick [
               write sector n;
-              Lwt_unix.sleep 5. >>= fun () -> Lwt.fail (Failure "write timeout")
+              Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "write timeout")
             ]
           end else begin
             let sector = Random.int64 nr_sectors in
@@ -194,7 +194,7 @@ let random_write_discard_compact nr_clusters stop_after =
             Printf.printf "-%!";
             Lwt.pick [
               discard sector n;
-              Lwt_unix.sleep 5. >>= fun () -> Lwt.fail (Failure "discard timeout")
+              Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "discard timeout")
             ]
           end )
         >>= fun () ->

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -44,7 +44,7 @@ let random_write_discard_compact nr_clusters stop_after =
       if !B.Debug.Setting.compact_mid_write
       then None (* running compact mid write races with the eraser thread *)
       else Some 2048L in
-    let config = B.Config.create ?keep_erased ~discard:true () in
+    let config = B.Config.create ?keep_erased ~discard:true ~runtime_asserts:true () in
     B.create block ~size ~lazy_refcounts:false ~config ()
     >>= function
     | Error _ -> failwith "B.create failed"

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -234,7 +234,7 @@ let write_discard_read_native sector_size size_sectors (start, length) () =
     let open Lwt.Infix in
     RawWriter.connect path
     >>= fun raw ->
-    let config = Writer.Config.create ~discard:true () in
+    let config = Writer.Config.create ~discard:true ~runtime_asserts:true () in
     let open Lwt_write_error.Infix in
     Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ~config ()
     >>= fun b ->
@@ -331,7 +331,8 @@ let check_full_disk () =
     Ramdisk.connect ~name:"test"
     >>= fun ramdisk ->
     let open Lwt_write_error.Infix in
-    B.create ramdisk ~size:gib ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create ramdisk ~size:gib ~config ()
     >>= fun b ->
 
     let open Lwt.Infix in
@@ -415,7 +416,8 @@ let qcow_tool size =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    B.create block ~size ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create block ~size ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
     B.disconnect qcow
@@ -436,7 +438,8 @@ let qcow_tool_resize ?ignore_data_loss size_from size_to =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    B.create block ~size:size_from ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     B.resize qcow ~new_size:size_to ?ignore_data_loss ()
     >>= fun () ->
@@ -459,7 +462,8 @@ let qcow_tool_bad_resize size_from size_to =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    B.create block ~size:size_from ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
     B.resize qcow ~new_size:size_to ()
@@ -484,7 +488,8 @@ let create_resize_equals_create size_from size_to =
     Block.connect path2
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    B.create block ~size:size_from ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     B.resize qcow ~new_size:size_to ()
     >>= fun () ->
@@ -498,7 +503,8 @@ let create_resize_equals_create size_from size_to =
     Block.connect path1
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    B.create block ~size:size_to ()
+    let config = B.Config.create ~runtime_asserts:true () in
+    B.create block ~size:size_to ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
     B.disconnect qcow
@@ -524,7 +530,7 @@ let create_write_discard_all_compact clusters () =
     >>= fun () ->
     Block.connect path
     >>= fun block ->
-    let config = B.Config.create ~discard:true () in
+    let config = B.Config.create ~discard:true ~runtime_asserts:true () in
     let open Lwt_write_error.Infix in
     B.create block ~size ~config ()
     >>= fun qcow ->
@@ -573,7 +579,7 @@ let create_write_discard_compact () =
     >>= fun () ->
     Block.connect path
     >>= fun block ->
-    let config = B.Config.create ~discard:true () in
+    let config = B.Config.create ~discard:true ~runtime_asserts:true () in
     let open Lwt_write_error.Infix in
     B.create block ~size ~config ()
     >>= fun qcow ->

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -9,5 +9,5 @@ let () =
        Pkg.bin "cli/main" ~dst:"qcow-tool";
        Pkg.test "lib_test/test" ~args:Cmd.(v "-runner" % "sequential");
        Pkg.test "lib_test/compact_random";
-       Pkg.test "lib_test/compact_random" ~args:Cmd.(v "-compact-mid-write");
+       Pkg.test "lib_test/compact_random" ~args:Cmd.(v "-compact-mid-write" % "-stop-after" % "16");
   ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -9,4 +9,5 @@ let () =
        Pkg.bin "cli/main" ~dst:"qcow-tool";
        Pkg.test "lib_test/test" ~args:Cmd.(v "-runner" % "sequential");
        Pkg.test "lib_test/compact_random";
+       Pkg.test "lib_test/compact_random" ~args:Cmd.(v "-compact-mid-write");
   ]


### PR DESCRIPTION
Previously the read/writer cluster locks were non-recursive, but this
was awkward because we wanted to take a batch of reads/writes, lock
all the metadata clusters for reading, acquire a write lock too if
necessary where some of the metadata clusters are shared.

This patch makes the locks optionally recursive: a `client` owns a set
of locks and can acquire the same lock it already has.

This patch also includes a test case which verifies that a compact
in the middle of a `write`, (a) doesn't deadlock; and (b) doesn't lose
data.

Signed-off-by: David Scott <dave@recoil.org>