### PR TITLE
Increase discard performance

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1568,7 +1568,6 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
         (* we can only discard whole clusters. We will explicitly zero non-cluster
            aligned discards in order to satisfy RZAT *)
         let to_erase = min n (Int64.sub sector' sector) in
-        Log.info (fun f -> f "erase %Ld %Ld" sector to_erase);
         erase t ~sector ~n:to_erase ()
         >>= fun () ->
 

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -767,8 +767,9 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                     let sectors_per_cluster = Int64.(div (1L <| t.cluster_bits) (of_int t.sector_size)) in
                     t.stats.Stats.nr_unmapped <- Int64.add t.stats.Stats.nr_unmapped sectors_per_cluster;
                     let data_cluster = Physical.cluster ~cluster_bits:t.cluster_bits data_offset in
-                    write_l2_table ?client t l2_offset a.Virtual.l2_index Physical.unmapped
-                    >>= fun () ->
+                    let l2_index_offset = Physical.shift l2_offset (8 * (Int64.to_int a.Virtual.l2_index)) in
+                    marshal_physical_address ?client t l2_index_offset Physical.unmapped
+                    >>= fun _ ->
                     Refcount.decr t data_cluster
                   end
                 ) (fun () ->

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1347,7 +1347,7 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
       | Ok () -> Lwt.return (Ok ()) in
     let cache = Cache.create ~read_cluster ~write_cluster () in
     let metadata = Metadata.make ~cache ~cluster_bits ~locks () in
-    let recycler = Recycler.create ~base ~sector_size ~cluster_bits ~cache ~locks ~metadata in
+    let recycler = Recycler.create ~base ~sector_size ~cluster_bits ~cache ~locks ~metadata ~runtime_asserts:config.Config.runtime_asserts in
     let lazy_refcounts = match h.Header.additional with Some { Header.lazy_refcounts = true; _ } -> true | _ -> false in
     let stats = Stats.zero in
     let t = ref None in

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -68,6 +68,8 @@ type t = {
   mutable roots: Cluster.IntervalSet.t;
   (* map from physical cluster to the physical cluster + offset of the reference.
      When a block is moved, this reference must be updated. *)
+  mutable copies: Cluster.IntervalSet.t;
+  (** Clusters which contain clusters as part of a move *)
   mutable moves: move Cluster.Map.t;
   (** The state of in-progress block moves, indexed by the source cluster *)
   mutable refs: reference Cluster.Map.t;
@@ -91,7 +93,12 @@ let get_last_block t =
       Cluster.IntervalSet.Interval.y @@ Cluster.IntervalSet.max_elt t.roots
     with Not_found ->
       max_ref in
-  max (Cluster.pred t.first_movable_cluster) @@ max max_ref max_root
+  let max_copies =
+    try
+      Cluster.IntervalSet.Interval.y @@ Cluster.IntervalSet.max_elt t.copies
+    with Not_found ->
+      max_root in
+  max (Cluster.pred t.first_movable_cluster) @@ max max_ref @@ max max_root max_copies
 
 let total_used t =
   Int64.of_int @@ Cluster.Map.cardinal t.refs
@@ -113,13 +120,16 @@ let total_moves t =
     | Referenced -> copying, copied, flushed, referenced + 1
   ) t.moves (0, 0, 0, 0)
 
+let total_copies t =
+  Cluster.to_int64 @@ Cluster.IntervalSet.cardinal t.copies
+
 let total_roots t =
   Cluster.to_int64 @@ Cluster.IntervalSet.cardinal t.roots
 
 let to_summary_string t =
   let copying, copied, flushed, referenced = total_moves t in
-  Printf.sprintf "%Ld used; %Ld junk; %Ld erased; %Ld available; %Ld roots; %d Copying; %d Copied; %d Flushed; %d Referenced; max_cluster = %s"
-    (total_used t) (total_free t) (total_erased t) (total_available t) (total_roots t)
+  Printf.sprintf "%Ld used; %Ld junk; %Ld erased; %Ld available; %Ld copies; %Ld roots; %d Copying; %d Copied; %d Flushed; %d Referenced; max_cluster = %s"
+    (total_used t) (total_free t) (total_erased t) (total_available t) (total_copies t) (total_roots t)
     copying copied flushed referenced (Cluster.to_string @@ get_last_block t)
 
 module Debug = struct
@@ -140,9 +150,10 @@ module Debug = struct
       let available = "available", t.available in
       let refs = "refs", refs in
       let moves = "moves", moves in
+      let copies = "copies", t.copies in
       let roots = "roots", t.roots in
       let cached = "cached", Cache.Debug.all_cached_clusters t.cache in
-      let all = [ junk; erased; available; refs; moves; roots ] in
+      let all = [ junk; erased; available; refs; moves; copies; roots ] in
       let leaked = List.fold_left diff whole_file (List.map snd all) in
       if leaks && (cardinal leaked <> Cluster.zero) then begin
         Log.err (fun f -> f "%s" (to_summary_string t));
@@ -170,8 +181,8 @@ module Debug = struct
       (* These must be disjoint *)
       if sharing then begin
         check @@ cross
-          [ junk; erased; available; refs; moves ]
-          [ junk; erased; available; refs; moves ];
+          [ junk; copies; erased; available; refs; moves ]
+          [ junk; copies; erased; available; refs; moves ];
         check @@ cross
           [ cached ]
           [ junk; erased; available ]
@@ -193,12 +204,13 @@ let make ~free ~refs ~cache ~first_movable_cluster ~runtime_asserts =
       let x = Cluster.of_int64 x and y = Cluster.of_int64 y in
       Cluster.IntervalSet.(add (Interval.make x y) acc)
     ) free Cluster.IntervalSet.empty in
+  let copies = Cluster.IntervalSet.empty in
   let roots = Cluster.IntervalSet.empty in
   let available = Cluster.IntervalSet.empty in
   let erased = Cluster.IntervalSet.empty in
   let moves = Cluster.Map.empty in
   let c = Lwt_condition.create () in
-  { junk; available; erased; roots; moves; refs; first_movable_cluster; cache; c; runtime_asserts }
+  { junk; available; erased; copies; roots; moves; refs; first_movable_cluster; cache; c; runtime_asserts }
 
 let zero =
   let free = Qcow_bitmap.make_empty ~initial_size:0 ~maximum_size:0 in
@@ -261,6 +273,19 @@ module Erased = struct
     Lwt_condition.signal t.c ()
 end
 
+module Copies = struct
+  let get t = t.erased
+  let add t more =
+    Log.debug (fun f -> f "Copies.add %s" (Sexplib.Sexp.to_string (Cluster.IntervalSet.sexp_of_t more)));
+    t.copies <- Cluster.IntervalSet.union t.copies more;
+    if t.runtime_asserts then Debug.check ~leaks:false t;
+    Lwt_condition.signal t.c ()
+  let remove t less =
+    t.copies <- Cluster.IntervalSet.diff t.copies less;
+    Lwt_condition.signal t.c ()
+end
+
+
 let wait t = Lwt_condition.wait t.c
 
 let find t cluster = Cluster.Map.find cluster t.refs
@@ -279,6 +304,7 @@ let set_move_state t move state =
     let dst' = Cluster.IntervalSet.(add (Interval.make dst dst) empty) in
     (* We always move into junk blocks *)
     Junk.remove t dst';
+    Copies.add t dst';
     t.moves <- Cluster.Map.add move.Move.src m t.moves
   | Some Copied, Flushed ->
     t.moves <- Cluster.Map.add move.Move.src m t.moves;
@@ -306,6 +332,7 @@ let cancel_move t cluster =
       t.moves <- Cluster.Map.remove cluster t.moves;
       let dst' = Cluster.IntervalSet.(add (Interval.make dst dst) empty) in
       (* The destination block can now be recycled *)
+      Copies.remove t dst';
       Junk.add t dst'
     | exception Not_found ->
       ()
@@ -313,7 +340,13 @@ let cancel_move t cluster =
 let complete_move t move =
   if not(Cluster.Map.mem move.Move.src t.moves)
   then Log.warn (fun f -> f "Not completing move state of cluster %s: operation cancelled" (Cluster.to_string move.Move.src))
-  else t.moves <- Cluster.Map.remove move.Move.src t.moves
+  else begin
+    let dst = Cluster.IntervalSet.(add (Interval.make move.Move.dst move.Move.dst) empty) in
+    Copies.remove t dst;
+    let src = Cluster.IntervalSet.(add (Interval.make move.Move.src move.Move.src) empty) in
+    Junk.add t src;
+    t.moves <- Cluster.Map.remove move.Move.src t.moves
+  end
 
 let add t rf cluster =
   let c, w = rf in

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -101,6 +101,9 @@ module Erased: MutableSet
 module Available: MutableSet
 (** Clusters which are available for reallocation *)
 
+module Copies: MutableSet
+(** Clusters which contain copies, as part of a compact *)
+
 val wait: t -> unit Lwt.t
 (** [wait t] wait for some amount of recycling work to become available, e.g.
     - junk could be created

--- a/lib/qcow_int64.ml
+++ b/lib/qcow_int64.ml
@@ -39,6 +39,8 @@ include M
 
 let round_up x size = mul (div (add x (pred size)) size) size
 
+let round_down x size = mul (div x size) size
+
 let sizeof _ = 8
 
 let read buf =

--- a/lib/qcow_int64.mli
+++ b/lib/qcow_int64.mli
@@ -29,6 +29,9 @@ val to_int64: t -> int64
 val round_up: int64 -> int64 -> int64
 (** [round_up value to] rounds [value] to the next multiple of [to] *)
 
+val round_down: int64 -> int64 -> int64
+(** [round_down value to] rounds [value] down to the multiple of [to] *)
+
 module IntervalSet: Qcow_s.INTERVAL_SET with type elt = t
 module Map: Map.S with type key = t
 

--- a/lib/qcow_metadata.ml
+++ b/lib/qcow_metadata.ml
@@ -131,12 +131,12 @@ let update ?client t cluster f =
        Cache.read t.cache cluster
        >>= fun data ->
        f { t; data; cluster }
-       >>= fun () ->
+       >>= fun result ->
        let open Lwt.Infix in
        Cache.write t.cache cluster data
        >>= function
        | Error `Is_read_only -> Lwt.return (Error `Is_read_only)
        | Error `Disconnected -> Lwt.return (Error `Disconnected)
        | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
-       | Ok () -> Lwt.return (Ok ())
+       | Ok () -> Lwt.return (Ok result)
     )

--- a/lib/qcow_metadata.mli
+++ b/lib/qcow_metadata.mli
@@ -76,6 +76,6 @@ val read_and_lock: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents * 
 val read: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents -> ('a, error) result Lwt.t) -> ('a, error) result Lwt.t
 (** Read the contents of the given cluster and provide them to the given function *)
 
-val update: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents -> (unit, write_error) result Lwt.t) -> (unit, write_error) result Lwt.t
+val update: ?client:Qcow_locks.Client.t -> t -> Cluster.t -> (contents -> ('a, write_error) result Lwt.t) -> ('a, write_error) result Lwt.t
 (** Read the contents of the given cluster, transform them through the given
     function and write the results back to disk *)

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -433,7 +433,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
         begin match Cluster.IntervalSet.take junk n with
         | None -> loop ()
         | Some (to_erase, _) ->
-          Log.info (fun f -> f "block recycler: should erase %s clusters" (Cluster.to_string @@ Cluster.IntervalSet.cardinal to_erase));
+          Log.debug (fun f -> f "block recycler: should erase %s clusters" (Cluster.to_string @@ Cluster.IntervalSet.cardinal to_erase));
           Qcow_cluster_map.with_roots cluster_map to_erase
             (fun () ->
               erase t to_erase
@@ -442,7 +442,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
               | Error `Disconnected -> Lwt.fail_with "Disconnected"
               | Error `Is_read_only -> Lwt.fail_with "Is_read_only"
               | Ok () ->
-                Log.info (fun f -> f "block recycler: finished erasing");
                 Qcow_cluster_map.Junk.remove cluster_map to_erase;
                 Qcow_cluster_map.Erased.add cluster_map to_erase;
                 Lwt.return_unit

--- a/lib/qcow_recycler.mli
+++ b/lib/qcow_recycler.mli
@@ -22,7 +22,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S): sig
 
   val create: base:B.t -> sector_size:int -> cluster_bits:int
     -> cache:Qcow_cache.t -> locks:Qcow_locks.t
-    -> metadata:Qcow_metadata.t -> t
+    -> metadata:Qcow_metadata.t -> runtime_asserts:bool -> t
   (** Initialise a cluster recycler over the given block device *)
 
   val set_cluster_map: t -> Qcow_cluster_map.t -> unit


### PR DESCRIPTION
Previously we would iterate over all data clusters to be discarded and set the L2 pointer to 0. Unfortunately this means we would often update and write out the same L2 cluster many times, if discarding many data clusters.

This patch holds the write lock on the L2 cluster and updates all the relevant pointers before flushing it out, exactly once.