### PR TITLE
Add an `assert_equal` for Qcow_cluster_map

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1387,6 +1387,8 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     } in
     Lwt_error.or_fail_with @@ make_cluster_map t'
     >>= fun cluster_map ->
+    if config.Config.runtime_asserts
+    then Qcow_cluster_map.Debug.assert_equal cluster_map cluster_map;
     (* An opened file may have junk at the end, which means that we would simultaneously
        allocate from it (get_last_block + n) as well as erase and recycle it.
        We should trim the file now so that it is safe to allocate from it as normal.

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -27,6 +27,8 @@ module Cache = Qcow_cache
 
 type reference = Cluster.t * int
 
+let string_of_reference (c, w) = Cluster.to_string c ^ ":" ^ (string_of_int w)
+
 type move_state =
   | Copying
   | Copied
@@ -189,6 +191,51 @@ module Debug = struct
       end
     end
     let assert_no_leaked_blocks t = check t
+
+  let assert_equal a b =
+    (* symmetric difference *)
+    let set_equals name a b =
+      let not_in_b = Cluster.IntervalSet.(diff a b) in
+      let not_in_a = Cluster.IntervalSet.(diff b a) in
+      if not(Cluster.IntervalSet.is_empty not_in_b) then begin
+        Log.err (fun f -> f "%s in a but not in b: %s" name
+          (Sexplib.Sexp.to_string_hum (Cluster.IntervalSet.sexp_of_t not_in_b))
+        );
+        false
+      end else if not(Cluster.IntervalSet.is_empty not_in_a) then begin
+        Log.err (fun f -> f "%s in a but not in a: %s" name
+          (Sexplib.Sexp.to_string_hum (Cluster.IntervalSet.sexp_of_t not_in_a))
+        );
+        false
+      end else true in
+    let junk = set_equals "junk" a.junk b.junk in
+    let erased = set_equals "erased"  a.erased b.erased in
+    let available = set_equals "available" a.available b.available in
+    let roots = set_equals "roots" a.roots b.roots in
+    let copies = set_equals "copies" a.copies b.copies in
+    let map_equals name pp a b =
+      Cluster.Map.fold (fun k v acc ->
+        let v' = try Some (Cluster.Map.find k b) with Not_found -> None in
+        if Some v <> v' then begin
+          Log.err (fun f -> f "%s: a has cluster %s -> %s but b has cluster %s -> %s"
+            name (Cluster.to_string k) (pp v) (Cluster.to_string k) (match v' with None -> "None" | Some v -> pp v)
+          );
+          false
+        end else acc
+      ) a true in
+    let moves = map_equals "moves" string_of_move a.moves b.moves in
+    let refs = map_equals "refs" string_of_reference a.refs b.refs in
+    let first_movable_cluster =
+      if a.first_movable_cluster <> b.first_movable_cluster then begin
+        Log.err (fun f -> f "a has first_movable_cluster = %s but b has first_movable_cluster = %s"
+          (Cluster.to_string a.first_movable_cluster) (Cluster.to_string b.first_movable_cluster)
+        );
+        false
+      end else true in
+    if not(junk && erased && available && roots && copies && moves && refs && first_movable_cluster) then begin
+      failwith "cluster maps are different"
+    end
+
 end
 
 module type MutableSet = sig

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -143,4 +143,7 @@ val to_summary_string: t -> string
 module Debug: sig
   val assert_no_leaked_blocks: t -> unit
   (** Check no blocks have gone missing *)
+
+  val assert_equal: t -> t -> unit
+  (** Check that 2 maps have equivalent contents *)
 end


### PR DESCRIPTION
We will use this in a later test to verify that the cluster map we construct from scratch equals the one we have maintained dynamically.

Signed-off-by: David Scott <dave@recoil.org>