### PR TITLE
Fix updating references

### DIFF
--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -411,10 +411,7 @@ let get_moves t =
 
 let is_immovable t cluster = cluster < t.first_movable_cluster
 
-let apply_moves t moves =
-  let substitutions = List.fold_left (fun acc { Move.src; dst } ->
-    Cluster.Map.add src dst acc
-  ) Cluster.Map.empty moves in
+let update_references t substitutions =
   let refs = Cluster.Map.fold (fun to_c (from_c, from_w) acc ->
     (* Has the cluster [from_c] been moved? *)
     let from_c' = try Cluster.Map.find from_c substitutions with Not_found -> from_c in

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -33,6 +33,12 @@ type move_state =
   | Flushed
   | Referenced
 
+let string_of_move_state = function
+  | Copying    -> "Copying"
+  | Copied     -> "Copied"
+  | Flushed    -> "Flushed"
+  | Referenced -> "Referenced"
+
 module Move = struct
   type t = { src: Cluster.t; dst: Cluster.t }
 
@@ -46,11 +52,7 @@ type move = {
 }
 
 let string_of_move m =
-  let state = match m.state with
-    | Copying    -> "Copying"
-    | Copied     -> "Copied"
-    | Flushed    -> "Flushed"
-    | Referenced -> "Referenced" in
+  let state = string_of_move_state m.state in
   Printf.sprintf "%s %s"
     (Move.to_string m.move)
     state
@@ -304,13 +306,17 @@ let set_move_state t move state =
     let dst' = Cluster.IntervalSet.(add (Interval.make dst dst) empty) in
     (* We always move into junk blocks *)
     Junk.remove t dst';
+    Log.debug (fun f -> f "Cluster %s None -> Copying" (Cluster.to_string move.Move.src));
     t.moves <- Cluster.Map.add move.Move.src m t.moves;
     Copies.add t dst'
   | Some Copied, Flushed ->
+    Log.debug (fun f -> f "Cluster %s Copied -> Flushed" (Cluster.to_string move.Move.src));
     t.moves <- Cluster.Map.add move.Move.src m t.moves;
     (* References now need to be rewritten *)
     Lwt_condition.signal t.c ();
-  | Some _, _ ->
+  | Some old, _ ->
+    Log.debug (fun f -> f "Cluster %s %s -> %s" (Cluster.to_string move.Move.src)
+      (string_of_move_state old) (string_of_move_state state));
     t.moves <- Cluster.Map.add move.Move.src m t.moves
   | None, _ ->
     Log.warn (fun f -> f "Not updating move state of cluster %s: operation cancelled" (Cluster.to_string move.Move.src))
@@ -326,7 +332,7 @@ let cancel_move t cluster =
            as if the write wasn't committed which is valid
          The only reason we still track this move is because when the next flush
          happens it is safe to add the src cluster to the set of junk blocks. *)
-      Log.info (fun f -> f "Not cancelling in-progress move of cluter %s: already Referenced" (Cluster.to_string cluster))
+      Log.info (fun f -> f "Not cancelling in-progress move of cluster %s: already Referenced" (Cluster.to_string cluster))
     | { move = { Move.dst; _ }; _ } ->
       Log.debug (fun f -> f "Cancelling in-progress move of cluster %s to %s" (Cluster.to_string cluster) (Cluster.to_string dst));
       t.moves <- Cluster.Map.remove cluster t.moves;

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -137,6 +137,19 @@ val get_last_block: t -> Cluster.t
     data blocks this will point to the last header block even though it is
     immovable. *)
 
+val is_immovable: t -> Cluster.t -> bool
+(** [is_immovable t cluster] is true if [cluster] is fixed and cannot be moved
+    i.e. it is before the first_movable_cluster i.e. it is part of the fixed
+    (L1) header structure. *)
+
+val apply_moves: t -> Move.t list -> unit
+(** [apply_moves t moves] updates the reference table following the given set
+    of completed moves. Any reference to a source block must be updated to the
+    destination block otherwise it will be left pointing to junk. Normally this
+    is guaranteed by the Metadata.Physical.set function, but when compacting we
+    split the operation into phases and copy the block first at the byte level,
+    leaving the map out-of-sync *)
+
 val to_summary_string: t -> string
 (** [to_summary_string t] returns a terse printable summary of [t] *)
 

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -142,9 +142,9 @@ val is_immovable: t -> Cluster.t -> bool
     i.e. it is before the first_movable_cluster i.e. it is part of the fixed
     (L1) header structure. *)
 
-val apply_moves: t -> Move.t list -> unit
-(** [apply_moves t moves] updates the reference table following the given set
-    of completed moves. Any reference to a source block must be updated to the
+val update_references: t -> Cluster.t Cluster.Map.t -> unit
+(** [update_references t subst] updates the reference table following the given set
+    of substitutions. Any reference to a source block must be updated to the
     destination block otherwise it will be left pointing to junk. Normally this
     is guaranteed by the Metadata.Physical.set function, but when compacting we
     split the operation into phases and copy the block first at the byte level,


### PR DESCRIPTION
- Previously we would update references in an arbitrary order, locking and unlocking clusters as we go. It's likely that many of the references are in the same clusters so we should try to minimise the amount of lock/unlock thrashing.
- Update the `t.Qcow_cluster_map.refs` in `update_references`: normally this is done by construction through `Metadata.Physical.set` but while compacting we deliberately copy the cluster at the byte level leaving the old reference intact-- we only update the reference when the copy has been flushed to disk
- Construct and apply a cluster substitution map as we `fold_left` in `update_references`: this ensures that if we move a block containing references and then move a block referenced by this block, we update the reference in the new block rather than the old. We used to do this but the functionality was lost and somehow the tests didn't catch it (!)

Signed-off-by: David Scott dave@recoil.org