### PR TITLE
test that the cluster reference map remains in sync

### DIFF
--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -195,26 +195,6 @@ module Debug = struct
     let assert_no_leaked_blocks t = check t
 
   let assert_equal a b =
-    (* symmetric difference *)
-    let set_equals name a b =
-      let not_in_b = Cluster.IntervalSet.(diff a b) in
-      let not_in_a = Cluster.IntervalSet.(diff b a) in
-      if not(Cluster.IntervalSet.is_empty not_in_b) then begin
-        Log.err (fun f -> f "%s in a but not in b: %s" name
-          (Sexplib.Sexp.to_string_hum (Cluster.IntervalSet.sexp_of_t not_in_b))
-        );
-        false
-      end else if not(Cluster.IntervalSet.is_empty not_in_a) then begin
-        Log.err (fun f -> f "%s in a but not in a: %s" name
-          (Sexplib.Sexp.to_string_hum (Cluster.IntervalSet.sexp_of_t not_in_a))
-        );
-        false
-      end else true in
-    let junk = set_equals "junk" a.junk b.junk in
-    let erased = set_equals "erased"  a.erased b.erased in
-    let available = set_equals "available" a.available b.available in
-    let roots = set_equals "roots" a.roots b.roots in
-    let copies = set_equals "copies" a.copies b.copies in
     let map_equals name pp a b =
       Cluster.Map.fold (fun k v acc ->
         let v' = try Some (Cluster.Map.find k b) with Not_found -> None in
@@ -234,7 +214,7 @@ module Debug = struct
         );
         false
       end else true in
-    if not(junk && erased && available && roots && copies && moves && refs && first_movable_cluster) then begin
+    if not(moves && refs && first_movable_cluster) then begin
       failwith "cluster maps are different"
     end
 

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -75,6 +75,8 @@ module type DEBUG = sig
 
   val assert_no_leaked_blocks: t -> unit
 
+  val assert_cluster_map_in_sync: t -> unit Lwt.t
+
   module Setting: sig
     val compact_mid_write: bool ref
   end

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -75,6 +75,8 @@ module type DEBUG = sig
 
   val assert_no_leaked_blocks: t -> unit
 
+  val assert_cluster_map_in_sync: t -> unit Lwt.t
+
   module Setting: sig
     val compact_mid_write: bool ref
     (** true means to trigger a compact part-way through a write to check that

--- a/lib_test/compact_random.ml
+++ b/lib_test/compact_random.ml
@@ -170,6 +170,8 @@ let random_write_discard_compact nr_clusters stop_after =
     let rec loop () =
       incr nr_iterations;
       B.Debug.assert_no_leaked_blocks qcow;
+      B.Debug.assert_cluster_map_in_sync qcow
+      >>= fun () ->
       if !nr_iterations = stop_after then Lwt.return (Ok ()) else begin
         (* Call flush so any erased blocks become reusable *)
         B.flush qcow

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -257,6 +257,8 @@ let write_discard_read_native sector_size size_sectors (start, length) () =
       if Cstruct.get_uint8 buf' i <> 0 then failwith "I did not Read Zero After TRIM"
     done;
     let open Lwt.Infix in
+    Writer.Debug.assert_cluster_map_in_sync b
+    >>= fun () ->
     Writer.disconnect b
     >>= fun () ->
     RawWriter.disconnect raw
@@ -561,6 +563,8 @@ let create_write_discard_all_compact clusters () =
     B.compact qcow ()
     >>= fun _report ->
     let open Lwt.Infix in
+    B.Debug.assert_cluster_map_in_sync qcow
+    >>= fun () ->
     B.disconnect qcow
     >>= fun () ->
     Block.disconnect block
@@ -688,6 +692,8 @@ let create_write_discard_compact () =
         check_contents data idx;
         Lwt.return_unit
       ) second
+    >>= fun () ->
+    B.Debug.assert_cluster_map_in_sync qcow
     >>= fun () ->
     B.disconnect qcow
     >>= fun () ->


### PR DESCRIPTION
This calls `assert_cluster_map_in_sync` from a few tests where it might have gotten out-of-sync.