### PR TITLE
Improve the error reporting when we encounter a duplicate reference

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1188,6 +1188,9 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                     ) (fun e ->
                       Log.err (fun f -> f "%s: low-level I/O exception %s" (describe_fn ()) (Printexc.to_string e));
                       Locks.Debug.dump_state t.locks;
+                      let cluster = Cluster.of_int (Int64.to_int work.sector / sectors_per_cluster) in
+                      Qcow_debug.check_references t.metadata t.cluster_map ~cluster_bits:t.cluster_bits cluster
+                      >>= fun _ ->
                       Lwt.fail e
                     )
                 )
@@ -1231,7 +1234,7 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                 ) (function
                   | Error.Duplicate_reference((c, w), (c', w'), target) as e ->
                     Log.err (fun f -> f "Duplicate_reference during %s" (describe_fn ()));
-                    Qcow_debug.on_duplicate_reference t.metadata t.cluster_map (c, w) (c', w') target
+                    Qcow_debug.on_duplicate_reference t.metadata t.cluster_map ~cluster_bits:t.cluster_bits (c, w) (c', w') target
                     >>= fun () ->
                     Lwt.fail e
                   | e -> Lwt.fail e
@@ -1280,6 +1283,9 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                     ) (fun e ->
                       Log.err (fun f -> f "%s: low-level I/O exception %s" (describe_fn ()) (Printexc.to_string e));
                       Locks.Debug.dump_state t.locks;
+                      let cluster = Cluster.of_int (Int64.to_int work.sector / sectors_per_cluster) in
+                      Qcow_debug.check_references t.metadata t.cluster_map ~cluster_bits:t.cluster_bits cluster
+                      >>= fun _ ->
                       Lwt.fail e
                     )
                 ) (fun () ->

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1191,6 +1191,8 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                       let cluster = Cluster.of_int (Int64.to_int work.sector / sectors_per_cluster) in
                       Qcow_debug.check_references t.metadata t.cluster_map ~cluster_bits:t.cluster_bits cluster
                       >>= fun _ ->
+                      Cache.Debug.check_disk t.cache
+                      >>= fun _ ->
                       Lwt.fail e
                     )
                 )
@@ -1285,6 +1287,8 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                       Locks.Debug.dump_state t.locks;
                       let cluster = Cluster.of_int (Int64.to_int work.sector / sectors_per_cluster) in
                       Qcow_debug.check_references t.metadata t.cluster_map ~cluster_bits:t.cluster_bits cluster
+                      >>= fun _ ->
+                      Cache.Debug.check_disk t.cache
                       >>= fun _ ->
                       Lwt.fail e
                     )

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -114,7 +114,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
   val check: B.t -> (check_result, [
     Mirage_block.error
     | `Reference_outside_file of int64 * int64
-    | `Duplicate_reference of int64 * int64 * int64
+    | `Duplicate_reference of (int64 * int) * (int64 * int) * int64
     | `Msg of string
   ]) result io
   (** [check t] performs sanity checks of the file, looking for errors.

--- a/lib/qcow.mllib
+++ b/lib/qcow.mllib
@@ -19,4 +19,5 @@ Qcow_cstructs
 Qcow_recycler
 Qcow_metadata
 Qcow_block_cache
+Qcow_debug
 Qcow

--- a/lib/qcow_cache.ml
+++ b/lib/qcow_cache.ml
@@ -60,6 +60,13 @@ let remove t cluster =
   then Printf.fprintf stderr "Dropping cache for cluster %s\n" (Cluster.to_string cluster);
   t.clusters <- Cluster.Map.remove cluster t.clusters
 
+let resize t new_size_clusters =
+  let to_keep, to_drop = Cluster.Map.partition (fun cluster _ -> cluster < new_size_clusters) t.clusters in
+  t.clusters <- to_keep;
+  if not(Cluster.Map.is_empty to_drop)
+  then Log.info (fun f -> f "After file resize dropping cached clusters: %s" (String.concat ", " @@ List.map Cluster.to_string @@ List.map fst @@ Cluster.Map.bindings to_drop))
+
+
 module Debug = struct
   let assert_not_cached t cluster =
     if Cluster.Map.mem cluster t.clusters then begin

--- a/lib/qcow_cache.ml
+++ b/lib/qcow_cache.ml
@@ -70,4 +70,30 @@ module Debug = struct
     Cluster.Map.fold (fun cluster _ set ->
       Cluster.IntervalSet.(add (Interval.make cluster cluster) set)
     ) t.clusters Cluster.IntervalSet.empty
+  let check_disk t =
+    let open Lwt.Infix in
+    let rec loop = function
+      | [] -> Lwt.return (Ok ())
+      | (cluster, expected) :: rest ->
+        begin
+          t.read_cluster cluster
+          >>= function
+          | Error e -> Lwt.return (Error e)
+          | Ok data ->
+            if not(Cstruct.equal expected data) then begin
+              Log.err (fun f -> f "Cache for cluster %s disagrees with disk" (Cluster.to_string cluster));
+              Log.err (fun f -> f "Cached:");
+              let buffer = Buffer.create 65536 in
+              Cstruct.hexdump_to_buffer buffer expected;
+              Log.err (fun f -> f "%s" (Buffer.contents buffer));
+              let buffer = Buffer.create 65536 in
+              Cstruct.hexdump_to_buffer buffer data;
+              Log.err (fun f -> f "On disk:");
+              Log.err (fun f -> f "%s" (Buffer.contents buffer));
+              Lwt.return (Ok ())
+            end else Lwt.return (Ok ())
+        end >>= function
+        | Error e -> Lwt.return (Error e)
+        | Ok () -> loop rest in
+    loop (Cluster.Map.bindings t.clusters)
 end

--- a/lib/qcow_cache.mli
+++ b/lib/qcow_cache.mli
@@ -34,6 +34,10 @@ val write: t -> Cluster.t -> Cstruct.t -> (unit, Mirage_block.write_error) resul
 val remove: t -> Cluster.t -> unit
 (** [remove t cluster] drops any cache associated with [cluster] *)
 
+val resize: t -> Cluster.t -> unit
+(** [resize t new_size_clusters] drops any cache entries which are beyond the new
+    file size. *)
+
 module Debug: sig
   val assert_not_cached: t -> Cluster.t -> unit
 

--- a/lib/qcow_cache.mli
+++ b/lib/qcow_cache.mli
@@ -38,4 +38,6 @@ module Debug: sig
   val assert_not_cached: t -> Cluster.t -> unit
 
   val all_cached_clusters: t -> Cluster.IntervalSet.t
+
+  val check_disk: t -> (unit, Mirage_block.error) result Lwt.t
 end

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -564,9 +564,8 @@ let complete_move t move =
   | Some Referenced ->
     t.moves <- Cluster.Map.remove move.Move.src t.moves;
     let dst = Cluster.IntervalSet.(add (Interval.make move.Move.dst move.Move.dst) empty) in
-    Copies.remove t dst;
-    let src = Cluster.IntervalSet.(add (Interval.make move.Move.src move.Move.src) empty) in
-    Junk.add t src
+    Copies.remove t dst
+    (* The source block will have already been added to Junk by the Metadata.Physical.set *)
   | Some old ->
     Log.err (fun f -> f "Illegal cluster move state transition: %s %s -> Completed" (Cluster.to_string move.Move.src)
       (string_of_move_state old)

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -283,6 +283,7 @@ let zero =
 let resize t new_size_clusters =
   let open Cluster.IntervalSet in
   let file = add (Interval.make Cluster.zero (Cluster.pred new_size_clusters)) empty in
+  Cache.resize t.cache new_size_clusters;
   t.junk <- inter t.junk file;
   t.erased <- inter t.erased file;
   t.available <- inter t.available file;

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -198,6 +198,15 @@ module Debug = struct
         check @@ cross
           [ cached ]
           [ junk; erased; available ]
+      end;
+      (* moves and copies should be the same *)
+      let d = union (diff (snd copies) (snd moves)) (diff (snd moves) (snd copies)) in
+      if not(is_empty d) then begin
+        Log.err (fun f -> f "%s" (to_summary_string t));
+        Log.err (fun f -> f "moves and refs are not the same");
+        Log.err (fun f -> f "moves = %s" (Sexplib.Sexp.to_string_hum (sexp_of_t (snd moves))));
+        Log.err (fun f -> f "refs  = %s" (Sexplib.Sexp.to_string_hum (sexp_of_t (snd refs))));
+        Log.err (fun f -> f "diff  = %s" (Sexplib.Sexp.to_string_hum (sexp_of_t d)))
       end
     end
     let assert_no_leaked_blocks t = check t

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -503,7 +503,7 @@ let add t rf cluster =
     if Cluster.Map.mem cluster t.refs then begin
       let c', w' = Cluster.Map.find cluster t.refs in
       Log.err (fun f -> f "Found two references to cluster %s: %s.%d and %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w (Cluster.to_string c') w');
-      failwith (Printf.sprintf "Found two references to cluster %s: %s.%d and %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w (Cluster.to_string c') w');
+      raise (Error.Duplicate_reference((Cluster.to_int64 c, w), (Cluster.to_int64 c', w'), Cluster.to_int64 cluster))
     end;
     if Cluster.IntervalSet.mem cluster t.junk then begin
       Log.err (fun f -> f "Adding a reference to junk cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -577,7 +577,6 @@ let add t rf cluster =
       failwith (Printf.sprintf "Adding a reference to available cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
     end;
     t.refs <- Cluster.Map.add cluster rf t.refs;
-    t.copies <- Cluster.IntervalSet.(remove (Interval.make cluster cluster) t.copies);
     ()
   end
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -497,6 +497,8 @@ let complete_move t move =
     Junk.add t src;
   end
 
+let is_moving t src = Cluster.Map.mem src t.moves
+
 let add t rf cluster =
   let c, w = rf in
   if cluster = Cluster.zero then () else begin
@@ -528,6 +530,7 @@ let add t rf cluster =
 let remove t cluster =
   t.junk <- Cluster.IntervalSet.(add (Interval.make cluster cluster) t.junk);
   t.refs <- Cluster.Map.remove cluster t.refs;
+  cancel_move t cluster;
   Lwt_condition.signal t.c ()
 
 let start_moves t =

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -519,7 +519,7 @@ let cancel_move t cluster =
            as if the write wasn't committed which is valid
          The only reason we still track this move is because when the next flush
          happens it is safe to add the src cluster to the set of junk blocks. *)
-      Log.info (fun f -> f "Not cancelling in-progress move of cluster %s: already Referenced" (Cluster.to_string cluster))
+      Log.debug (fun f -> f "Not cancelling in-progress move of cluster %s: already Referenced" (Cluster.to_string cluster))
     | { move = { Move.dst; _ }; _ } ->
       Log.debug (fun f -> f "Cancelling in-progress move of cluster %s to %s" (Cluster.to_string cluster) (Cluster.to_string dst));
       t.moves <- Cluster.Map.remove cluster t.moves;

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -582,8 +582,8 @@ let add t rf cluster =
   end
 
 let remove t cluster =
-  t.junk <- Cluster.IntervalSet.(add (Interval.make cluster cluster) t.junk);
   t.refs <- Cluster.Map.remove cluster t.refs;
+  Junk.add t (Cluster.IntervalSet.(add (Interval.make cluster cluster) empty));
   cancel_move t cluster;
   Lwt_condition.signal t.c ()
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -295,7 +295,15 @@ module Junk = struct
     if t.runtime_asserts then Debug.check ~leaks:false t;
     Lwt_condition.signal t.c ()
   let remove t less =
+    let open Cluster.IntervalSet in
+    let old_junk = t.junk in
     t.junk <- Cluster.IntervalSet.diff t.junk less;
+    if (Cluster.sub (cardinal old_junk) (cardinal less)) <> (cardinal t.junk) then begin
+      Log.err (fun f -> f "Junk.remove: clusters were not in junk");
+      Log.err (fun f -> f "Junk = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t old_junk));
+      Log.err (fun f -> f "To remove = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t less));
+      failwith "Junk.remove: clusters were not in junk"
+    end;
     Lwt_condition.signal t.c ()
 end
 
@@ -314,7 +322,14 @@ module Available = struct
     Log.debug (fun f -> f "Available.remove %s"
       (Sexplib.Sexp.to_string @@ sexp_of_t less)
     );
+    let old_available = t.available in
     t.available <- Cluster.IntervalSet.diff t.available less;
+    if (Cluster.sub (cardinal old_available) (cardinal less)) <> (cardinal t.available) then begin
+      Log.err (fun f -> f "Available.remove: clusters were not in junk");
+      Log.err (fun f -> f "Available = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t old_available));
+      Log.err (fun f -> f "To remove = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t less));
+      failwith "Available.remove: clusters were not in available"
+    end;
     Lwt_condition.signal t.c ()
 end
 
@@ -326,7 +341,15 @@ module Erased = struct
     if t.runtime_asserts then Debug.check ~leaks:false t;
     Lwt_condition.signal t.c ()
   let remove t less =
-    t.erased <- Cluster.IntervalSet.diff t.erased less;
+    let open Cluster.IntervalSet in
+    let old_erased = t.erased in
+    t.erased <- diff t.erased less;
+    if (Cluster.sub (cardinal old_erased) (cardinal less)) <> (cardinal t.erased) then begin
+      Log.err (fun f -> f "Erased.remove: clusters were not in erased");
+      Log.err (fun f -> f "Erased = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t old_erased));
+      Log.err (fun f -> f "To remove = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t less));
+      failwith "Erased.remove: clusters were not in erased"
+    end;
     Lwt_condition.signal t.c ()
 end
 
@@ -338,7 +361,15 @@ module Copies = struct
     if t.runtime_asserts then Debug.check ~leaks:false t;
     Lwt_condition.signal t.c ()
   let remove t less =
-    t.copies <- Cluster.IntervalSet.diff t.copies less;
+    let open Cluster.IntervalSet in
+    let old_copies = t.copies in
+    t.copies <- diff t.copies less;
+    if (Cluster.sub (cardinal old_copies) (cardinal less)) <> (cardinal t.copies) then begin
+      Log.err (fun f -> f "Copies.remove: clusters were not in copies");
+      Log.err (fun f -> f "Copies = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t old_copies));
+      Log.err (fun f -> f "To remove = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t less));
+      failwith "Copies.remove: clusters were not in copies"
+    end;
     Lwt_condition.signal t.c ()
 end
 
@@ -361,7 +392,15 @@ module Roots = struct
     if t.runtime_asserts then Debug.check ~leaks:false t;
     Lwt_condition.signal t.c ()
   let remove t less =
-    t.roots <- Cluster.IntervalSet.diff t.roots less;
+    let open Cluster.IntervalSet in
+    let old_roots = t.roots in
+    t.roots <- diff t.roots less;
+    if (Cluster.sub (cardinal old_roots) (cardinal less)) <> (cardinal t.roots) then begin
+      Log.err (fun f -> f "Roots.remove: clusters were not in roots");
+      Log.err (fun f -> f "Roots = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t old_roots));
+      Log.err (fun f -> f "To remove = %s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ sexp_of_t less));
+      failwith "Roots.remove: clusters were not in roots"
+    end;
     Lwt_condition.signal t.c ()
 end
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -94,18 +94,23 @@ let get_last_block t =
     try
       fst @@ Cluster.Map.max_binding t.refs
     with Not_found ->
-      Cluster.pred t.first_movable_cluster in
+      Cluster.zero in
   let max_root =
     try
       Cluster.IntervalSet.Interval.y @@ Cluster.IntervalSet.max_elt t.roots
     with Not_found ->
-      max_ref in
+      Cluster.zero in
   let max_copies =
     try
       Cluster.IntervalSet.Interval.y @@ Cluster.IntervalSet.max_elt t.copies
     with Not_found ->
-      max_root in
-  max (Cluster.pred t.first_movable_cluster) @@ max max_ref @@ max max_root max_copies
+      Cluster.zero in
+  let max_move =
+    try
+      fst @@ Cluster.Map.max_binding t.moves
+    with Not_found ->
+      Cluster.zero in
+  max (Cluster.pred t.first_movable_cluster) @@ max max_ref @@ max max_root @@ max max_move max_copies
 
 let total_used t =
   Int64.of_int @@ Cluster.Map.cardinal t.refs

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -24,6 +24,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 open Qcow_types
 module Cache = Qcow_cache
+module Error = Qcow_error
 
 type reference = Cluster.t * int
 

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -193,8 +193,11 @@ module Debug = struct
       (* These must be disjoint *)
       if sharing then begin
         check @@ cross
-          [ junk; copies; erased; available; refs ]
-          [ junk; copies; erased; available; refs ];
+          [ junk; erased; available; refs ]
+          [ junk; erased; available; refs ];
+        check @@ cross
+          [ junk; copies; erased; available ]
+          [ junk; copies; erased; available ];
         check @@ cross
           [ cached ]
           [ junk; erased; available ]

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -507,14 +507,17 @@ let add t rf cluster =
     end;
     if Cluster.IntervalSet.mem cluster t.junk then begin
       Log.err (fun f -> f "Adding a reference to junk cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
+      (try Debug.check t with _ -> ());
       failwith (Printf.sprintf "Adding a reference to junk cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
     end;
     if Cluster.IntervalSet.mem cluster t.erased then begin
       Log.err (fun f -> f "Adding a reference to erased cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
+      (try Debug.check t with _ -> ());
       failwith (Printf.sprintf "Adding a reference to erased cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
     end;
     if Cluster.IntervalSet.mem cluster t.available then begin
       Log.err (fun f -> f "Adding a reference to available cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
+      (try Debug.check t with _ -> ());
       failwith (Printf.sprintf "Adding a reference to available cluster %s in %s.%d" (Cluster.to_string cluster) (Cluster.to_string c) w);
     end;
     t.refs <- Cluster.Map.add cluster rf t.refs;

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -73,6 +73,8 @@ module type MutableSet = sig
   val remove: t -> Cluster.IntervalSet.t -> unit
   (** [remove t less] removes [less] from the set *)
 
+  val mem: t -> Cluster.t -> bool
+  (** [mem t cluster] is true if [cluster] is in [t] *)
 end
 
 val zero: t

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -133,6 +133,9 @@ val moves: t -> move Cluster.Map.t
 val set_move_state: t -> Move.t -> move_state -> unit
 (** Update the state of the given move operation *)
 
+val is_moving: t -> Cluster.t -> bool
+(** [is_moving t cluster] returns true if [cluster] is still moving *)
+
 val cancel_move: t -> Cluster.t -> unit
 (** [cancel_move cluster] cancels any in-progress move of cluster [cluster].
     This should be called with the cluster write lock held whenever there has

--- a/lib/qcow_debug.ml
+++ b/lib/qcow_debug.ml
@@ -1,0 +1,55 @@
+(*
+ * Copyright (C) 2017 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let src =
+  let src = Logs.Src.create "qcow" ~doc:"qcow2-formatted BLOCK device" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Error = Qcow_error
+module Physical = Qcow_physical
+module Metadata = Qcow_metadata
+open Qcow_types
+
+let on_duplicate_reference metadata cluster_map (c, w) (c', w') target =
+  let open Error.Lwt_write_error.Infix in
+  let rec follow (c, w) (target: Physical.t) =
+    Metadata.read metadata c
+      (fun contents ->
+        let p = Metadata.Physical.of_contents contents in
+        let target' = Metadata.Physical.get p w in
+        let descr = Printf.sprintf "Physical.get %s:%d = %s (%s %s)"
+          (Cluster.to_string c) w (Physical.to_string target')
+          (if target = target' then "=" else "<>")
+          (Physical.to_string target) in
+        if target <> target'
+        then Log.err (fun f -> f "%s" descr)
+        else Log.info (fun f -> f "%s" descr);
+        Lwt.return (Ok ())
+      )
+    >>= fun () ->
+    match Qcow_cluster_map.find cluster_map c with
+    | exception Not_found ->
+      Log.err (fun f -> f "No reference to cluster %s" (Cluster.to_string c));
+      Lwt.return (Ok ())
+    | c', w' -> follow (c', w') (Physical.make ~is_mutable:true ~is_compressed:false @@ Cluster.to_int c) in
+  let target = Physical.make ~is_mutable:true ~is_compressed:true @@ Int64.to_int target in
+  follow (Cluster.of_int64 c', w') target
+  >>= fun () ->
+  follow (Cluster.of_int64 c, w) target

--- a/lib/qcow_debug.ml
+++ b/lib/qcow_debug.ml
@@ -27,29 +27,49 @@ module Physical = Qcow_physical
 module Metadata = Qcow_metadata
 open Qcow_types
 
-let on_duplicate_reference metadata cluster_map (c, w) (c', w') target =
+let check_on_disk_reference metadata ~cluster_bits (c, w) target =
+  Metadata.read metadata c
+    (fun contents ->
+      let p = Metadata.Physical.of_contents contents in
+      let target' = Metadata.Physical.get p w in
+      let target_cluster = Physical.cluster ~cluster_bits target in
+      let target'_cluster = Physical.cluster ~cluster_bits target' in
+      let descr = Printf.sprintf "Physical.get %s:%d = %s (%s %s)"
+        (Cluster.to_string c) w (Cluster.to_string target'_cluster)
+        (if target = target' then "=" else "<>")
+        (Cluster.to_string target_cluster) in
+      if target <> target'
+      then Log.err (fun f -> f "%s" descr)
+      else Log.info (fun f -> f "%s" descr);
+      Lwt.return (Ok ())
+    )
+
+let rec check_references metadata cluster_map ~cluster_bits (cluster: Cluster.t) =
   let open Error.Lwt_write_error.Infix in
-  let rec follow (c, w) (target: Physical.t) =
-    Metadata.read metadata c
-      (fun contents ->
-        let p = Metadata.Physical.of_contents contents in
-        let target' = Metadata.Physical.get p w in
-        let descr = Printf.sprintf "Physical.get %s:%d = %s (%s %s)"
-          (Cluster.to_string c) w (Physical.to_string target')
-          (if target = target' then "=" else "<>")
-          (Physical.to_string target) in
-        if target <> target'
-        then Log.err (fun f -> f "%s" descr)
-        else Log.info (fun f -> f "%s" descr);
-        Lwt.return (Ok ())
-      )
+  match Qcow_cluster_map.find cluster_map cluster with
+  | exception Not_found ->
+    if Qcow_cluster_map.is_immovable cluster_map cluster
+    then Log.info (fun f -> f "Cluster %s is an L1 cluster" (Cluster.to_string cluster))
+    else Log.err (fun f -> f "No reference to cluster %s" (Cluster.to_string cluster));
+    Lwt.return (Ok ())
+  | c', w' ->
+    let target = Physical.make ~is_mutable:true ~is_compressed:false (Cluster.to_int cluster lsl cluster_bits) in
+    check_on_disk_reference metadata ~cluster_bits (c', w') target
+    >>= fun () ->
+    check_references metadata cluster_map ~cluster_bits c'
+
+let on_duplicate_reference metadata cluster_map ~cluster_bits (c, w) (c', w') cluster =
+  let open Error.Lwt_write_error.Infix in
+  let cluster = Cluster.of_int64 cluster in
+  let rec follow (c, w) (cluster: Cluster.t) =
+    let target = Physical.make ~is_mutable:true ~is_compressed:true (Cluster.to_int cluster lsl cluster_bits) in
+    check_on_disk_reference metadata ~cluster_bits (c, w) target
     >>= fun () ->
     match Qcow_cluster_map.find cluster_map c with
     | exception Not_found ->
       Log.err (fun f -> f "No reference to cluster %s" (Cluster.to_string c));
       Lwt.return (Ok ())
-    | c', w' -> follow (c', w') (Physical.make ~is_mutable:true ~is_compressed:false @@ Cluster.to_int c) in
-  let target = Physical.make ~is_mutable:true ~is_compressed:true @@ Int64.to_int target in
-  follow (Cluster.of_int64 c', w') target
+    | c', w' -> follow (c', w') c in
+  follow (Cluster.of_int64 c', w') cluster
   >>= fun () ->
-  follow (Cluster.of_int64 c, w) target
+  follow (Cluster.of_int64 c, w) cluster

--- a/lib/qcow_debug.mli
+++ b/lib/qcow_debug.mli
@@ -1,0 +1,20 @@
+(*
+ * Copyright (C) 2017 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+val on_duplicate_reference: Qcow_metadata.t -> Qcow_cluster_map.t ->
+   (int64 * int) -> (int64 * int) -> int64 ->
+   (unit, [> `Disconnected | `Is_read_only | `Msg of string | `Unimplemented ]) result Lwt.t

--- a/lib/qcow_debug.mli
+++ b/lib/qcow_debug.mli
@@ -14,7 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+open Qcow_types
 
-val on_duplicate_reference: Qcow_metadata.t -> Qcow_cluster_map.t ->
+val on_duplicate_reference: Qcow_metadata.t -> Qcow_cluster_map.t -> cluster_bits:int ->
    (int64 * int) -> (int64 * int) -> int64 ->
    (unit, [> `Disconnected | `Is_read_only | `Msg of string | `Unimplemented ]) result Lwt.t
+
+val check_references: Qcow_metadata.t -> Qcow_cluster_map.t -> cluster_bits:int -> Cluster.t ->
+  (unit, [> `Disconnected | `Is_read_only | `Msg of string | `Unimplemented ]) result Lwt.t
+(** [check_references metadata map cluster_bits target] follows the back references
+    from physical offset [target], verifying the references on disk as it goes *)

--- a/lib/qcow_error.ml
+++ b/lib/qcow_error.ml
@@ -88,3 +88,5 @@ module Lwt_write_error = struct
     | Error `Disconnected -> Lwt.fail_with "disconnected"
     | Ok x -> Lwt.return x
 end
+
+exception Duplicate_reference of (int64 * int) * (int64 * int) * int64

--- a/lib/qcow_error.mli
+++ b/lib/qcow_error.mli
@@ -74,3 +74,5 @@ end
      [< `Disconnected | `Is_read_only | `Msg of string | `Unimplemented ])
       result Lwt.t -> 'a Lwt.t
 end
+
+exception Duplicate_reference of (int64 * int) * (int64 * int) * int64

--- a/lib/qcow_locks.ml
+++ b/lib/qcow_locks.ml
@@ -132,11 +132,6 @@ module Debug = struct
   include Qcow_rwlock.Debug
 
   let dump_state t =
-    Cluster.Map.iter
-      (fun cluster (lock, rf) ->
-        Log.info (fun f -> f "Cluster %s refcount %d locks = %s"
-          (Cluster.to_string cluster) rf
-          (Sexplib.Sexp.to_string @@ Qcow_rwlock.sexp_of_t lock)
-        )
-      ) t.locks
+    let locks = List.map fst @@ List.map snd @@ Cluster.Map.bindings t.locks in
+    Log.info (fun f -> f "%s" (Sexplib.Sexp.to_string_hum ~indent:2 @@ Qcow_rwlock.sexp_of_ts locks))
 end

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -419,7 +419,6 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
         | _, Some x, _ -> Lwt.return (Some x)
         | None, _, Some x when x < nr_junk ->
           if not(Cluster.Map.is_empty moves) then begin
-            Log.info (fun f -> f "Discards (%Ld) over threshold (%Ld) but moves in progress: waiting for them to complete" nr_junk x);
             Lwt.return None
           end else begin
             (* Wait for the junk data to stabilise before starting to copy *)

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -289,7 +289,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                         (String.concat ", " @@ List.map Qcow_cluster_map.string_of_move @@ List.concat @@ List.map snd flushed)
                       );
                       let open Error.Lwt_write_error.Infix in
-                      Qcow_debug.on_duplicate_reference t.metadata cluster_map (c, w) (c', w') target
+                      Qcow_debug.on_duplicate_reference t.metadata cluster_map ~cluster_bits:t.cluster_bits (c, w) (c', w') target
                       >>= fun () ->
                       Lwt.fail e
                   )

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -13,6 +13,7 @@ let ( <| ) = Int64.shift_left
 let ( |> ) = Int64.shift_right
 
 module Cache = Qcow_cache
+module Error = Qcow_error
 module Locks = Qcow_locks
 module Metadata = Qcow_metadata
 module Physical = Qcow_physical
@@ -223,65 +224,74 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                   (fun c ->
                     Log.debug (fun f -> f "Updating references in cluster %s" (Cluster.to_string ref_cluster));
                     let addresses = Metadata.Physical.of_contents c in
-                    let result = List.fold_left
-                      (fun acc ({ move = { Move.src; dst }; _ } as move) -> match acc with
-                        | Error e -> Error e
-                        | Ok subst ->
-                          begin match Qcow_cluster_map.find cluster_map src with
-                          | exception Not_found ->
-                            (* Block was probably discarded after we started running. *)
-                            Log.warn (fun f -> f "Not copying cluster %s to %s: %s has been discarded"
-                              (Cluster.to_string src) (Cluster.to_string dst) (Cluster.to_string src)
-                            );
-                            Ok subst
-                          | ref_cluster, ref_cluster_within ->
-                            if not(Cluster.Map.mem src (Qcow_cluster_map.moves cluster_map)) then begin
-                              Log.debug (fun f -> f "Not rewriting reference in %s :%d from %s to %s: move as been cancelled"
-                                (Cluster.to_string ref_cluster) ref_cluster_within
-                                (Cluster.to_string src) (Cluster.to_string dst)
+                    try
+                      let result = List.fold_left
+                        (fun acc ({ move = { Move.src; dst }; _ } as move) -> match acc with
+                          | Error e -> Error e
+                          | Ok subst ->
+                            begin match Qcow_cluster_map.find cluster_map src with
+                            | exception Not_found ->
+                              (* Block was probably discarded after we started running. *)
+                              Log.warn (fun f -> f "Not copying cluster %s to %s: %s has been discarded"
+                                (Cluster.to_string src) (Cluster.to_string dst) (Cluster.to_string src)
                               );
                               Ok subst
-                            end else begin
-                              (* Read the current value in the referencing cluster as a sanity check *)
-                              let old_reference = Metadata.Physical.get addresses ref_cluster_within in
-                              let old_cluster = Qcow_physical.cluster ~cluster_bits:t.cluster_bits old_reference in
-                              if old_cluster <> src then begin
-                                Log.err (fun f -> f "Rewriting reference in %s :%d from %s to %s, old reference actually pointing to %s"
+                            | ref_cluster, ref_cluster_within ->
+                              if not(Cluster.Map.mem src (Qcow_cluster_map.moves cluster_map)) then begin
+                                Log.debug (fun f -> f "Not rewriting reference in %s :%d from %s to %s: move as been cancelled"
                                   (Cluster.to_string ref_cluster) ref_cluster_within
                                   (Cluster.to_string src) (Cluster.to_string dst)
-                                  (Cluster.to_string old_cluster)
                                 );
-                                assert false
-                              end;
-                              Log.debug (fun f -> f "Rewriting reference in %s :%d from %s to %s"
-                                (Cluster.to_string ref_cluster) ref_cluster_within
-                                (Cluster.to_string src) (Cluster.to_string dst)
-                              );
-                              (* Preserve any flags but update the pointer *)
-                              let dst' = Cluster.to_int dst lsl t.cluster_bits in
-                              let new_reference = Qcow_physical.make ~is_mutable:(Qcow_physical.is_mutable old_reference) ~is_compressed:(Qcow_physical.is_compressed old_reference) dst' in
-                              Metadata.Physical.set addresses ref_cluster_within new_reference;
-                              nr_updated := Int64.succ !nr_updated;
-                              set_move_state cluster_map move.move Referenced;
-                              (* The move cannot be cancelled now that the metadata has
-                                 been updated. *)
-                              Ok (Cluster.Map.add src dst subst)
+                                Ok subst
+                              end else begin
+                                (* Read the current value in the referencing cluster as a sanity check *)
+                                let old_reference = Metadata.Physical.get addresses ref_cluster_within in
+                                let old_cluster = Qcow_physical.cluster ~cluster_bits:t.cluster_bits old_reference in
+                                if old_cluster <> src then begin
+                                  Log.err (fun f -> f "Rewriting reference in %s :%d from %s to %s, old reference actually pointing to %s"
+                                    (Cluster.to_string ref_cluster) ref_cluster_within
+                                    (Cluster.to_string src) (Cluster.to_string dst)
+                                    (Cluster.to_string old_cluster)
+                                  );
+                                  assert false
+                                end;
+                                Log.debug (fun f -> f "Rewriting reference in %s :%d from %s to %s"
+                                  (Cluster.to_string ref_cluster) ref_cluster_within
+                                  (Cluster.to_string src) (Cluster.to_string dst)
+                                );
+                                (* Preserve any flags but update the pointer *)
+                                let dst' = Cluster.to_int dst lsl t.cluster_bits in
+                                let new_reference = Qcow_physical.make ~is_mutable:(Qcow_physical.is_mutable old_reference) ~is_compressed:(Qcow_physical.is_compressed old_reference) dst' in
+                                Metadata.Physical.set addresses ref_cluster_within new_reference;
+                                nr_updated := Int64.succ !nr_updated;
+                                set_move_state cluster_map move.move Referenced;
+                                (* The move cannot be cancelled now that the metadata has
+                                   been updated. *)
+                                Ok (Cluster.Map.add src dst subst)
                             end
                           end
                       ) (Ok subst) moves in
-                    match result with
-                    | Error e -> Lwt.return (Error e)
-                    | Ok subst ->
-                      (* If `ref_cluster` is an L1 table entry then `src` must be an
-                         L2 block, and the values in `cluster_map.refs` will point to it.
-                         These need to be redirected to `dst` otherwise the `cluster_map`
-                         will be out-of-sync. This only happens because we bypass the
-                         `Metadata.Physical.set` function in the block copier. *)
-                      if Qcow_cluster_map.is_immovable cluster_map ref_cluster then begin
-                        Log.info (fun f -> f "Cluster %s is L1: we must remap L2 references" (Cluster.to_string ref_cluster));
-                        Qcow_cluster_map.update_references cluster_map subst
-                      end;
-                      Lwt.return (Ok subst)
+                      match result with
+                      | Error e -> Lwt.return (Error e)
+                      | Ok subst ->
+                        (* If `ref_cluster` is an L1 table entry then `src` must be an
+                           L2 block, and the values in `cluster_map.refs` will point to it.
+                           These need to be redirected to `dst` otherwise the `cluster_map`
+                           will be out-of-sync. This only happens because we bypass the
+                           `Metadata.Physical.set` function in the block copier. *)
+                        if Qcow_cluster_map.is_immovable cluster_map ref_cluster then begin
+                          Log.info (fun f -> f "Cluster %s is L1: we must remap L2 references" (Cluster.to_string ref_cluster));
+                          Qcow_cluster_map.update_references cluster_map subst
+                        end;
+                        Lwt.return (Ok subst)
+                    with Error.Duplicate_reference((c, w), (c', w'), (target: int64)) as e ->
+                      Log.err (fun f -> f "Duplicate_reference during update_references of %s"
+                        (String.concat ", " @@ List.map Qcow_cluster_map.string_of_move @@ List.concat @@ List.map snd flushed)
+                      );
+                      let open Error.Lwt_write_error.Infix in
+                      Qcow_debug.on_duplicate_reference t.metadata cluster_map (c, w) (c', w') target
+                      >>= fun () ->
+                      Lwt.fail e
                   )
               ) (fun () ->
                 Locks.unlock lock;

--- a/lib/qcow_recycler.ml
+++ b/lib/qcow_recycler.ml
@@ -291,7 +291,11 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                       let open Error.Lwt_write_error.Infix in
                       Qcow_debug.on_duplicate_reference t.metadata cluster_map ~cluster_bits:t.cluster_bits (c, w) (c', w') target
                       >>= fun () ->
+                      Qcow_cluster_map.Debug.assert_no_leaked_blocks cluster_map;
                       Lwt.fail e
+                    | e ->
+                      Qcow_cluster_map.Debug.assert_no_leaked_blocks cluster_map;
+                      raise e
                   )
               ) (fun () ->
                 Locks.unlock lock;

--- a/lib/qcow_rwlock.mli
+++ b/lib/qcow_rwlock.mli
@@ -19,6 +19,8 @@ type t [@@deriving sexp_of]
 (** A lock which permits multiple concurrent threads to acquire it for reading
     but demands exclusivity for writing *)
 
+type ts = t list [@@deriving sexp_of]
+
 val make: (unit -> string) -> t
 (** [make describe_fn] creates a new lock, where [describe_fn ()] returns a
     human-readable description string suitable for debug output. *)


### PR DESCRIPTION
Previously at runtime we would `assert false` which didn't help debugging much. This patch will perform some analysis and look for a discrepancy between the references on disk and the references in the map.