### PR TITLE
Allow cluster_bits to be overridden

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1658,11 +1658,10 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
         erase t ~sector:(Int64.add sector' to_discard) ~n:(Int64.sub n' to_discard) ()
     )
 
-  let create base ~size ?(lazy_refcounts=true) ?(config = Config.default) () =
+  let create base ~size ?(lazy_refcounts=true) ?(cluster_bits=16) ?(config = Config.default) () =
     let version = `Three in
     let backing_file_offset = 0L in
     let backing_file_size = 0l in
-    let cluster_bits = 16 in
     let cluster_size = 1 lsl cluster_bits in
     let crypt_method = `None in
     (* qemu-img places the refcount table next in the file and only

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -145,11 +145,11 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
     Lwt.return (Ok (Metadata.Physical.get addresses within, lock))
 
   let update_header t h =
-    let page = Io_page.(to_cstruct (get 1)) in
-    match Header.write h page with
+    let cluster = malloc t.h in
+    match Header.write h cluster with
     | Result.Ok _ -> begin
       let open Lwt.Infix in
-        B.write t.base 0L [ page ]
+        B.write t.base 0L [ cluster ]
         >>= function
         | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
         | Error `Disconnected -> Lwt.return (Error `Disconnected)

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -55,12 +55,19 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
   end
 
   val create: B.t -> size:int64 -> ?lazy_refcounts:bool
+      -> ?cluster_bits:int
       -> ?config:Config.t -> unit
       -> (t, write_error) result io
-  (** [create block ~size ?lazy_refcounts ()] initialises a qcow-formatted
-      image on [block] with virtual size [size] in bytes. By default the file
-      will use lazy refcounts, but this can be overriden by supplying
-      [~lazy_refcounts:false] *)
+  (** [create block ~size ?lazy_refcounts ?cluster_bits ?config ()] initialises
+      a qcow-formatted image on [block] with virtual size [size] in bytes.
+
+      By default the file will use lazy refcounts, but this can be overriden by supplying
+      [~lazy_refcounts:false]. By default the file will use 64KiB clusters (= 16 bits)
+      but this can be overridden by supplying [?cluster_bits]. Note the cluster size
+      must be greater than the sector size on the underlying block device.
+
+      The [?config] argument does not affect the on-disk format but rather the
+      behaviour as seen from this client. *)
 
   val connect: ?config:Config.t -> B.t -> t io
   (** [connect ?config block] connects to an existing qcow-formatted image on


### PR DESCRIPTION
The default value is 16 i.e. 64KiB clusters. This PR adds the ability to request a different value at `connect` time. For the moment this is mainly useful for testing, as using a lower value will stress the metadata handling more.