### PR TITLE
Add circleci build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+general:
+  artifacts:
+    - build/qcow-tool
+machine:
+  xcode:
+    version: "7.3"
+  environment:
+    MACOSX_DEPLOYMENT_TARGET: "10.10"
+    OPAMYES: "1"
+compile:
+  override:
+    - mkdir build/
+    - brew install opam
+    - opam init
+    - opam pin add qcow .
+    - eval `opam config env` && cp `which qcow-tool` build/
+test:
+  override:
+    - echo "Nothing here"
+


### PR DESCRIPTION
In Docker for Mac, we package qcow-tool ourself. It will be better to compile it in a proper build. 
This is the first step for getting this artifact. 

For the libev dependency, I don't really know what should I do. I tried a lot of things to get the dylib compiled with the correct flags without luck. Can I get help on this ? Thanks!
