### PR TITLE
Add CLI commands "dehydrate" and "rehydrate"

### DIFF
--- a/cli/jbuild
+++ b/cli/jbuild
@@ -1,7 +1,7 @@
 (executables
  ((names (main))
   (libraries   (qcow io-page.unix logs logs.fmt sha))
-  (preprocess  no_preprocessing)
+  (preprocess (pps (ppx_sexp_conv)))
 ))
 
 (install

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -300,6 +300,43 @@ let sha_cmd =
   Term.(ret(pure Impl.sha $ common_options_t $ filename)),
   Term.info "sha" ~sdocs:_common_options ~doc ~man
 
+let dehydrate_cmd =
+  let doc = "Extract only the metadata blocks for debugging" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Create 2 files: one containing metadata blocks and the second containing \
+        a map of block to physical offset in the file. When rehydrated the resulting \
+        file has the same structure as the original, but with none of the data. It \
+        is therefore safe to share the dehydrated file with other people without \
+        fearing data leaks. ";
+    `P "To dehydrate a file input.qcow2 and produce dehydrated.{map,meta}:";
+    `P "qcow-tool dehydrate input.qcow2 dehydrated";
+  ] @ help in
+  let output =
+    let doc = Printf.sprintf "Prefix of the output files" in
+    Arg.(value & pos 1 string "dehydrated" & info [] ~doc) in
+  Term.(ret(pure Impl.dehydrate $ common_options_t $ filename $ output)),
+  Term.info "dehydrate" ~sdocs:_common_options ~doc ~man
+
+let rehydrate_cmd =
+  let doc = "Create a qcow2 file from a previously dehydrated file" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Convert the files created by a previous call to dehydrate into a valid \
+        qcow file which has the same structure as the original, but with none of \
+        the data.";
+    `P "To rehydrate files dehydrated.{map,meta} into output.qcow2:";
+    `P "qcow-tool rehydrate dehydrated output.qcow2";
+  ] @ help in
+  let filename =
+    let doc = Printf.sprintf "Prefix of the input files" in
+    Arg.(value & pos 0 string "dehydrated" & info [] ~doc) in
+  let output =
+    let doc = Printf.sprintf "Output qcow2 file" in
+    Arg.(value & pos 1 string "output.qcow2" & info [] ~doc) in
+  Term.(ret(pure Impl.rehydrate $ common_options_t $ filename $ output)),
+  Term.info "rehydrate" ~sdocs:_common_options ~doc ~man
+
 let default_cmd =
   let doc = "manipulate virtual disks stored in qcow2 files" in
   let man = help in
@@ -308,7 +345,7 @@ let default_cmd =
 
 let cmds = [info_cmd; create_cmd; check_cmd; repair_cmd; encode_cmd; decode_cmd;
   write_cmd; read_cmd; mapped_cmd; resize_cmd; discard_cmd; compact_cmd;
-  pattern_cmd; sha_cmd ]
+  pattern_cmd; sha_cmd; dehydrate_cmd; rehydrate_cmd ]
 
 let _ =
   Logs.set_reporter (Logs_fmt.reporter ());

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -17,6 +17,7 @@
 module Error = Qcow_error
 module Header = Qcow_header
 module Physical = Qcow_physical
+module Int64 = Qcow_types.Int64
 
 module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
   include Mirage_block_lwt.S
@@ -156,5 +157,8 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
       (** true means to trigger a compact part-way through a write to check that
           the write completes properly after the compact *)
     end
+
+    val metadata_blocks: t -> Int64.IntervalSet.t
+    (** Return the set of physical disk offsets containing metadata *)
   end
 end

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -144,7 +144,17 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
   val get_stats: t -> Stats.t
   (** [get_stats t] returns the runtime statistics of a device *)
 
-  module Debug: Qcow_s.DEBUG
-    with type t = t
-     and type error = write_error
+  module Debug: sig
+    val check_no_overlaps: t -> (unit, write_error) result Lwt.t
+
+    val assert_no_leaked_blocks: t -> unit
+
+    val assert_cluster_map_in_sync: t -> unit Lwt.t
+
+    module Setting: sig
+      val compact_mid_write: bool ref
+      (** true means to trigger a compact part-way through a write to check that
+          the write completes properly after the compact *)
+    end
+  end
 end

--- a/lib/qcow_cluster_map.ml
+++ b/lib/qcow_cluster_map.ml
@@ -238,6 +238,13 @@ module Debug = struct
       failwith "cluster maps are different"
     end
 
+  let metadata_blocks t =
+    let open Cluster.IntervalSet in
+    let header = add (Interval.make Cluster.zero (Cluster.pred t.first_movable_cluster)) empty in
+    (* All clusters which reference other clusters must be metadata *)
+    Cluster.Map.fold (fun _ (cluster, _) set ->
+      add (Interval.make cluster cluster) set
+    ) t.refs header
 end
 
 module type MutableSet = sig

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -176,4 +176,7 @@ module Debug: sig
 
   val assert_equal: t -> t -> unit
   (** Check that 2 maps have equivalent contents *)
+
+  val metadata_blocks: t -> Cluster.IntervalSet.t
+  (** Return the set of blocks containing metadata *)
 end

--- a/lib/qcow_s.ml
+++ b/lib/qcow_s.ml
@@ -67,21 +67,6 @@ module type RESIZABLE_BLOCK = sig
       mode *)
 end
 
-module type DEBUG = sig
-  type t
-  type error
-
-  val check_no_overlaps: t -> (unit, error) result Lwt.t
-
-  val assert_no_leaked_blocks: t -> unit
-
-  val assert_cluster_map_in_sync: t -> unit Lwt.t
-
-  module Setting: sig
-    val compact_mid_write: bool ref
-  end
-end
-
 module type INTERVAL_SET = sig
   type elt
   (** The type of the set elements *)

--- a/lib/qcow_s.mli
+++ b/lib/qcow_s.mli
@@ -67,23 +67,6 @@ module type RESIZABLE_BLOCK = sig
       mode *)
 end
 
-module type DEBUG = sig
-  type t
-  type error
-
-  val check_no_overlaps: t -> (unit, error) result Lwt.t
-
-  val assert_no_leaked_blocks: t -> unit
-
-  val assert_cluster_map_in_sync: t -> unit Lwt.t
-
-  module Setting: sig
-    val compact_mid_write: bool ref
-    (** true means to trigger a compact part-way through a write to check that
-        the write completes properly after the compact *)
-  end
-end
-
 module type INTERVAL_SET = sig
   type elt
   (** The type of the set elements *)


### PR DESCRIPTION
When debugging problems in the field, we need to analyse very large files. It isn't reasonable to expect someone to email us 100 GiB of their personal data: we need something safer and smaller.

This PR adds 2 new CLI commands:

- `qcow-tool dehydrate input.qcow2 output`: creates 2 files: `output.map` describing the metadata blocks and `output.meta` containing the metadata blocks. Crucially no user data is included.
- `qcow-tool rehydrate output output.qcow2`: consumes the 2 files created above and creates a new `output.qcow2` file with the same metadata structure as `input.qcow2` but where all the data blocks contain zeroes.