### PR TITLE
Add prometheus metrics

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        qcow)
   (public_name qcow)
-  (libraries (astring cmdliner cstruct logs lwt mirage-block mirage-block-unix mirage-types-lwt ppx_sexp_conv ppx_tools ppx_type_conv))
+  (libraries (astring cmdliner cstruct logs lwt mirage-block mirage-block-unix mirage-types-lwt ppx_sexp_conv ppx_tools ppx_type_conv prometheus))
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv)))))
 

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1553,22 +1553,14 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
       | Ok (h, _) ->
         make config base h
         >>= fun t ->
-        make_cluster_map t
-        >>= function
-        | Error (`Reference_outside_file (src, dst)) -> Lwt.fail_with (Printf.sprintf "reference from %Ld to outside file %Ld: image is corrupt" src dst)
-        | Error `Unimplemented -> Lwt.fail_with "Unimplemented"
-        | Error `Disconnected -> Lwt.fail_with "Disconnected"
-        | Error (`Msg m) -> Lwt.fail_with m
-        | Ok block_map ->
         let open Qcow_cluster_map in
-        let free = total_free block_map in
-        let used = total_used block_map in
+        let free = total_free t.cluster_map in
+        let used = total_used t.cluster_map in
         Log.info (fun f -> f "image has %Ld free sectors and %Ld used sectors" free used);
         Lwt.return t
 
   let check base =
     let open Lwt.Infix in
-
     let open Qcow_cluster_map in
     Lwt.catch
       (fun () ->

--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1036,7 +1036,7 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
 
     let map = make ~free ~refs:(!refs) ~first_movable_cluster ~cache:t.cache
       ~runtime_asserts:t.config.Config.runtime_asserts
-      ~id in
+      ~id ~cluster_size:(Int64.to_int cluster_size) in
 
     Lwt.return (Ok map)
 

--- a/lib/qcow.mli
+++ b/lib/qcow.mli
@@ -23,6 +23,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
 
   module Config: sig
     type t = {
+      id: string; (** unique name for prometheus metrics *)
       discard: bool; (** true if `discard` will be enabled at runtime *)
       keep_erased: int64 option; (** size of erased free pool in sectors *)
       compact_after_unmaps: int64 option; (** automatically compact after n sectors are unmapped *)
@@ -32,7 +33,9 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) : sig
     }
     (** Runtime configuration of a device *)
 
-    val create: ?discard:bool ->
+    val create:
+      ?id:string ->
+      ?discard:bool ->
       ?keep_erased:int64 ->
       ?compact_after_unmaps:int64 ->
       ?check_on_connect:bool ->

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -82,7 +82,7 @@ val zero: t
 
 val make: free:Qcow_bitmap.t -> refs:reference Cluster.Map.t -> cache:Qcow_cache.t
   -> first_movable_cluster:Cluster.t -> runtime_asserts:bool
-  -> id:string option -> t
+  -> id:string option -> cluster_size:int -> t
 (** Given a set of free clusters, and the first cluster which can be moved
     (i.e. that isn't fixed header), construct an empty cluster map. *)
 

--- a/lib/qcow_cluster_map.mli
+++ b/lib/qcow_cluster_map.mli
@@ -81,7 +81,8 @@ val zero: t
 (** A cluster map for a zero-length disk *)
 
 val make: free:Qcow_bitmap.t -> refs:reference Cluster.Map.t -> cache:Qcow_cache.t
-  -> first_movable_cluster:Cluster.t -> runtime_asserts:bool -> t
+  -> first_movable_cluster:Cluster.t -> runtime_asserts:bool
+  -> id:string option -> t
 (** Given a set of free clusters, and the first cluster which can be moved
     (i.e. that isn't fixed header), construct an empty cluster map. *)
 

--- a/lib/qcow_config.ml
+++ b/lib/qcow_config.ml
@@ -16,6 +16,7 @@
  *)
 
 type t = {
+  id: string;
   discard: bool;
   keep_erased: int64 option;
   compact_after_unmaps: int64 option;
@@ -23,14 +24,20 @@ type t = {
   runtime_asserts: bool;
   read_only: bool;
 }
-let create ?(discard=false) ?keep_erased ?compact_after_unmaps ?(check_on_connect=true) ?(runtime_asserts=false) ?(read_only=false) () =
-  { discard; keep_erased; compact_after_unmaps; check_on_connect; runtime_asserts; read_only }
-let to_string t = Printf.sprintf "discard=%b;keep_erased=%scompact_after_unmaps=%s;check_on_connect=%b;runtime_asserts=%b;read_only=%b"
-    t.discard
+let fresh_id =
+  let id = ref 0 in
+  fun () ->
+    let result = "unknown_" ^ (string_of_int !id) in
+    incr id;
+    result
+let create ?(id = fresh_id ()) ?(discard=false) ?keep_erased ?compact_after_unmaps ?(check_on_connect=true) ?(runtime_asserts=false) ?(read_only=false) () =
+  { id; discard; keep_erased; compact_after_unmaps; check_on_connect; runtime_asserts; read_only }
+let to_string t = Printf.sprintf "id=%s;discard=%b;keep_erased=%scompact_after_unmaps=%s;check_on_connect=%b;runtime_asserts=%b;read_only=%b"
+    t.id t.discard
     (match t.keep_erased with None -> "0" | Some x -> Int64.to_string x)
     (match t.compact_after_unmaps with None -> "0" | Some x -> Int64.to_string x)
     t.check_on_connect t.runtime_asserts t.read_only
-let default = { discard = false; keep_erased = None; compact_after_unmaps = None; check_on_connect = true; runtime_asserts = false; read_only = false }
+let default () = { id = fresh_id (); discard = false; keep_erased = None; compact_after_unmaps = None; check_on_connect = true; runtime_asserts = false; read_only = false }
 let of_string txt =
   let open Astring in
   try
@@ -40,6 +47,7 @@ let of_string txt =
         | None -> t
         | Some (k, v) ->
           begin match String.Ascii.lowercase k with
+            | "id" -> { t with id = v }
             | "discard" -> { t with discard = bool_of_string v }
             | "keep_erased" ->
               let keep_erased = if v = "0" then None else Some (Int64.of_string v) in
@@ -52,6 +60,6 @@ let of_string txt =
             | "read_only" -> { t with read_only = bool_of_string v }
             | x -> failwith ("Unknown qcow configuration key: " ^ x)
           end
-      ) default strings)
+      ) (default ()) strings)
   with
   | e -> Error (`Msg (Printexc.to_string e))

--- a/lib/qcow_config.mli
+++ b/lib/qcow_config.mli
@@ -16,6 +16,9 @@
  *)
 
 type t = {
+  id: string;
+  (** unique name for the prometheus metrics *)
+
   discard: bool;
   (** discard (aka TRIM) is enabled *)
 
@@ -35,12 +38,14 @@ type t = {
   (** guarantee to not modify the file *)
 }
 
-val create: ?discard:bool -> ?keep_erased:int64 ->
+val create:
+  ?id:string ->
+  ?discard:bool -> ?keep_erased:int64 ->
   ?compact_after_unmaps:int64 -> ?check_on_connect:bool ->
   ?runtime_asserts:bool -> ?read_only:bool ->
   unit -> t
 
-val default: t
+val default: unit -> t
 (** default configuration values *)
 
 val to_string: t -> string

--- a/lib/qcow_types.mli
+++ b/lib/qcow_types.mli
@@ -52,6 +52,8 @@ module Cluster : sig
 
   include Qcow_s.NUM with type t := t
 
+  val to_float: t -> float
+
   val round_up: t -> t -> t
   (** [round_up value to] rounds [value] to the next multiple of [to] *)
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -234,7 +234,7 @@ let write_discard_read_native sector_size size_sectors (start, length) () =
     let open Lwt.Infix in
     RawWriter.connect path
     >>= fun raw ->
-    let config = Writer.Config.create ~discard:true ~runtime_asserts:true () in
+    let config = Writer.Config.create ~discard:true ~runtime_asserts:true ~id:"id" () in
     let open Lwt_write_error.Infix in
     Writer.create raw ~size:Int64.(mul size_sectors (of_int sector_size)) ~config ()
     >>= fun b ->
@@ -333,7 +333,7 @@ let check_full_disk () =
     Ramdisk.connect ~name:"test"
     >>= fun ramdisk ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create ramdisk ~size:gib ~config ()
     >>= fun b ->
 
@@ -418,7 +418,7 @@ let qcow_tool size =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create block ~size ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
@@ -440,7 +440,7 @@ let qcow_tool_resize ?ignore_data_loss size_from size_to =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     B.resize qcow ~new_size:size_to ?ignore_data_loss ()
@@ -464,7 +464,7 @@ let qcow_tool_bad_resize size_from size_to =
     Block.connect path
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
@@ -490,7 +490,7 @@ let create_resize_equals_create size_from size_to =
     Block.connect path2
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create block ~size:size_from ~config ()
     >>= fun qcow ->
     B.resize qcow ~new_size:size_to ()
@@ -505,7 +505,7 @@ let create_resize_equals_create size_from size_to =
     Block.connect path1
     >>= fun block ->
     let open Lwt_write_error.Infix in
-    let config = B.Config.create ~runtime_asserts:true () in
+    let config = B.Config.create ~runtime_asserts:true ~id:"id" () in
     B.create block ~size:size_to ~config ()
     >>= fun qcow ->
     let open Lwt.Infix in
@@ -532,7 +532,7 @@ let create_write_discard_all_compact clusters () =
     >>= fun () ->
     Block.connect path
     >>= fun block ->
-    let config = B.Config.create ~discard:true ~runtime_asserts:true () in
+    let config = B.Config.create ~discard:true ~runtime_asserts:true ~id:"id" () in
     let open Lwt_write_error.Infix in
     B.create block ~size ~config ()
     >>= fun qcow ->
@@ -583,7 +583,7 @@ let create_write_discard_compact () =
     >>= fun () ->
     Block.connect path
     >>= fun block ->
-    let config = B.Config.create ~discard:true ~runtime_asserts:true () in
+    let config = B.Config.create ~discard:true ~runtime_asserts:true ~id:"id" () in
     let open Lwt_write_error.Infix in
     B.create block ~size ~config ()
     >>= fun qcow ->

--- a/qcow.opam
+++ b/qcow.opam
@@ -13,6 +13,7 @@ depends: [
   "astring"
   "cstruct"
   "result"
+  "prometheus"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}


### PR DESCRIPTION
This exposes metrics for each of the categories of clusters tracked by the garbage collector:

- `used`: a Gauge counting the number of bytes of user data
- `size`: a Gauge counting the number of bytes in the file
- `junk`: a Counter counting the number of bytes which become junk
- `erased`: a Counter counting the number of bytes which are erased
- `available`: a Counter counting the number of bytes which become available for reallocation
- `roots`: a Counter counting the number of bytes registered as roots
- `copying`: a Counter counting the number of copies started
- `copied`: a Counter counting the number of copies completed
- `flushed`: a Counter counting the number of bytes flushed
- `referenced`: a Counter counting the number of bytes re-referenced

and general I/O metrics:

- `reads`: a Counter counting the number of bytes read
- `writes`: a Counter counting the number of bytes written
- `discards`: a Counter counting the number of bytes discarded

The metrics are parameterised over a single label `id`, values of which uniquely identify the device (e.g. `vda`)

Signed-off-by: David Scott <dave@recoil.org>