### PR TITLE
perf: make interval union calculations faster

### DIFF
--- a/lib/qcow_diet.ml
+++ b/lib/qcow_diet.ml
@@ -341,7 +341,11 @@ let rec node x y l r =
     (* completely within *)
     | Node n -> Node n
 
-  let union = fold add
+  let union a b =
+    let a' = cardinal a and b' = cardinal b in
+    if a' > b'
+    then fold add b a
+    else fold add a b
 
   let merge l r = match l, r with
     | l, Empty -> l


### PR DESCRIPTION
The IntervalSet `union` is roughly:
```
  let union a b = fold add a b
```
where elements of `a` are added to `b`. Therefore if one of the
sets is much smaller than the other we should make it the 1st
argument.

Running a `qcow-tool compact` on files created with
`qcow-tool pattern --pattern 2` shows the following speedup:
```
Size/GiB      Before/seconds    After/seconds
1             20                1
2             87                3
8             1369              15
16            ??                25
64            ??                139
```
Signed-off-by: David Scott <dave@recoil.org>