### PR TITLE
compact: hook back up the progress_cb

### DIFF
--- a/lib/qcow.ml
+++ b/lib/qcow.ml
@@ -1082,12 +1082,12 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                 let cluster_bits = Int32.to_int t.h.Header.cluster_bits in
                 let sectors_per_cluster = Int64.div (1L <| cluster_bits) sector_size in
 
-                let one_pass () =
+                let one_pass ?progress_cb () =
                   Qcow_cluster_map.Debug.assert_no_leaked_blocks map;
 
                   let moves = Qcow_cluster_map.start_moves map in
                   let open Lwt_write_error.Infix in
-                  Recycler.move_all t.recycler moves
+                  Recycler.move_all ?progress_cb t.recycler moves
                   >>= fun () ->
                   (* Flush now so that if we crash after updating some of the references, the
                      destination blocks will contain the correct data. *)
@@ -1111,13 +1111,13 @@ module Make(Base: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S) = struct
                   | Error `Disconnected -> Lwt.return (Error `Disconnected)
                   | Error `Is_read_only -> Lwt.return (Error `Is_read_only)
                   | Ok () -> Lwt.return (Ok refs_updated) in
-                one_pass ()
+                one_pass ~progress_cb:(fun ~percent -> progress_cb ~percent:((percent * 80) / 100)) ()
                 >>= fun refs_updated ->
                 if refs_updated <> 0L
                 then Log.info (fun f -> f "Pass 1: %Ld references updated" refs_updated);
                 (* modifying a L2 metadata block will have cancelled the move, so
                    perform an additional pass. *)
-                one_pass ()
+                one_pass ~progress_cb:(fun ~percent -> progress_cb ~percent:(80 + (percent * 4) / 100)) ()
                 >>= fun refs_updated' ->
                 if refs_updated' <> 0L
                 then Log.info (fun f -> f "Pass 2: %Ld references updated" refs_updated');

--- a/lib/qcow_recycler.mli
+++ b/lib/qcow_recycler.mli
@@ -43,7 +43,7 @@ module Make(B: Qcow_s.RESIZABLE_BLOCK)(Time: Mirage_time_lwt.S): sig
   val copy: t -> Cluster.t -> Cluster.t -> (unit, B.write_error) result Lwt.t
   (** [copy src dst] copies the cluster [src] to [dst] *)
 
-  val move_all: t -> Qcow_cluster_map.Move.t list -> (unit, Qcow_metadata.write_error) result Lwt.t
+  val move_all: ?progress_cb:(percent:int -> unit) -> t -> Qcow_cluster_map.Move.t list -> (unit, Qcow_metadata.write_error) result Lwt.t
   (** [move_all t mv] perform the initial data copy of the move operations [mv] *)
 
   val update_references: t -> (int64, Qcow_metadata.write_error) result Lwt.t


### PR DESCRIPTION
In a recent refactor the `progress_cb` was removed. This patch adds
it back in, with the convention that the first pass (copying data blocks)
will constitute the (arbitrary) first 80% of progress, while the second
pass (rewriting references and copying metadata blocks) constitutes
the last 20%.

Signed-off-by: David Scott <dave@recoil.org>