### PR TITLE
cli: compact: add --progress-fd <file descriptor>

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -18,6 +18,7 @@
 type t = {
   debug: bool;
   progress: bool;
+  progress_fd: int option;
 }
 
-let make debug progress = { debug; progress }
+let make debug progress progress_fd = { debug; progress; progress_fd }

--- a/cli/jbuild
+++ b/cli/jbuild
@@ -1,6 +1,6 @@
 (executables
  ((names (main))
-  (libraries   (qcow io-page.unix logs logs.fmt sha))
+  (libraries   (qcow io-page.unix logs logs.fmt sha unix-type-representations))
   (preprocess (pps (ppx_sexp_conv)))
 ))
 

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -40,7 +40,10 @@ let common_options_t =
   let progress =
     let doc = "Display a progress bar." in
     Arg.(value & flag & info ["progress"] ~docs ~doc) in
-  Term.(pure Common.make $ debug $ progress)
+  let progress_fd =
+    let doc = "Write machine-readable progress output." in
+    Arg.(value & opt (some int) None & info [ "progress-fd"] ~docs ~doc) in
+  Term.(pure Common.make $ debug $ progress $ progress_fd)
 
 let filename =
   let doc = Printf.sprintf "Path to the qcow2 file." in

--- a/qcow-tool.opam
+++ b/qcow-tool.opam
@@ -14,6 +14,7 @@ depends: [
   "cmdliner"
   "cstruct"
   "result"
+  "unix-type-representations"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}


### PR DESCRIPTION
If selected, this will write json-formatted progress records like this:

   `{ "progress": 50 }`

to the given file descriptor.

Signed-off-by: David Scott <dave@recoil.org>