### PR TITLE
Only qcow-tool needs io-page-unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: trusty
 env:
   global:
     - PACKAGE="qcow-tool" OCAML_VERSION=4.03
+    - EXTRA_REMOTES="https://github.com/djs55/opam-repository.git#io-page"
     - PINS="qcow:."
     - COV_CONF="export TESTS=--enable-tests"
     - PRE_INSTALL_HOOK="sudo apt-get install qemu-utils -y"

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        qcow)
   (public_name qcow)
-  (libraries (astring cmdliner cstruct logs lwt mirage-block mirage-block-unix mirage-types-lwt ppx_sexp_conv ppx_tools ppx_type_conv prometheus))
+  (libraries (astring cmdliner cstruct logs lwt mirage-block mirage-block-unix mirage-types-lwt ppx_sexp_conv ppx_tools ppx_type_conv prometheus io-page-unix))
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv)))))
 

--- a/pkg/META
+++ b/pkg/META
@@ -1,8 +1,0 @@
-description = "Qcow2 image format"
-version = "%%VERSION_NUM%%"
-requires="astring cmdliner cstruct fmt logs lwt io-page mirage-types-lwt mirage-time mirage-time-lwt mirage-block mirage-block-lwt mirage-block-unix result sexplib"
-archive(byte) = "qcow.cma"
-plugin(byte) = "qcow.cma"
-archive(native) = "qcow.cmxa"
-plugin(native) = "qcow.cmxs"
-exists_if = "qcow.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,13 +1,3 @@
 #!/usr/bin/env ocaml
 #use "topfind"
-#require "topkg"
-open Topkg
-
-let () =
-  Pkg.describe "qcow" @@ fun c ->
-  Ok [ Pkg.mllib "lib/qcow.mllib";
-       Pkg.bin "cli/main" ~dst:"qcow-tool";
-       Pkg.test "lib_test/test" ~args:Cmd.(v "-runner" % "sequential");
-       Pkg.test "lib_test/compact_random";
-       Pkg.test "lib_test/compact_random" ~args:Cmd.(v "-compact-mid-write" % "-stop-after" % "16");
-  ]
+#require "topkg-jbuilder.auto"

--- a/qcow.opam
+++ b/qcow.opam
@@ -5,6 +5,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+doc: "https://mirage.github.io/ocaml-qcow"
 tags: [
   "org:mirage"
 ]

--- a/qcow.opam
+++ b/qcow.opam
@@ -26,7 +26,6 @@ depends: [
   "logs"
   "fmt" {>="0.8.2"}
   "io-page"
-  "ocamlfind" {build}
   "jbuilder" {build}
   "ppx_tools" {build}
   "ppx_sexp_conv" {build}

--- a/qcow.opam
+++ b/qcow.opam
@@ -25,7 +25,7 @@ depends: [
   "sexplib"
   "logs"
   "fmt" {>="0.8.2"}
-  "io-page"
+  "io-page-unix" {>= "2.0.0"}
   "jbuilder" {build}
   "ppx_tools" {build}
   "ppx_sexp_conv" {build}


### PR DESCRIPTION
- the library currently needs `io-page` but only the CLI needs `io-page-unix`
- refresh `topkg` configuration
