### PR TITLE
Prepare for release 0.14.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.14.0 (2026-04-10)
+- qcow_stream: Fix handling of images >4tb (last-genius #136)
+
 ## 0.13.0 (2026-02-06)
 - qcow_stream: Breaking changes to the interface, with the allocated data
   clusters now returned in Qcow_mapping.t. Great reductions in memory usage,

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,6 @@
 (lang dune 3.18)
 
 (cram enable)
-(subst disabled)
 
 (name qcow)
 (formatting (enabled_for ocaml))


### PR DESCRIPTION
Re-enables dune subst and adds the changelog allow dune-release to cut a new release