### PR TITLE
opam metadata fixes from opam-repository's CI

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,7 @@
   (authors "David Scott")
   (maintenance_intent "latest")
   (depends
-    (ocaml (and :with_test (>= 4.13.0)))
+    (ocaml (>= 4.13.0))
     (alcotest :with-test)
     (qcow-types (= :version))
     cstruct-lwt

--- a/dune-project
+++ b/dune-project
@@ -43,7 +43,7 @@
   (maintenance_intent "latest")
   (depends
     (ocaml (>= 4.13.0))
-    (alcotest :with-test)
+    (alcotest (and :with-test (>= 1.2.0)))
     (qcow-types (= :version))
     cstruct-lwt
     io-page

--- a/qcow-stream.opam
+++ b/qcow-stream.opam
@@ -21,6 +21,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/qcow-stream.opam
+++ b/qcow-stream.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
 depends: [
   "dune" {>= "3.18"}
   "ocaml" {>= "4.13.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.2.0"}
   "qcow-types" {= version}
   "cstruct-lwt"
   "io-page"

--- a/qcow-stream.opam
+++ b/qcow-stream.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-qcow"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
 depends: [
   "dune" {>= "3.18"}
-  "ocaml" {with_test & >= "4.13.0"}
+  "ocaml" {>= "4.13.0"}
   "alcotest" {with-test}
   "qcow-types" {= version}
   "cstruct-lwt"

--- a/qcow-tool.opam
+++ b/qcow-tool.opam
@@ -47,3 +47,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+x-ci-accept-failures: [
+  "freebsd-14.3"
+  "macos-homebrew"
+  "opensuse-15.6"
+  "opensuse-16.0"
+  "opensuse-tumbleweed"
+]

--- a/qcow-tool.opam.template
+++ b/qcow-tool.opam.template
@@ -11,3 +11,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+x-ci-accept-failures: [
+  "freebsd-14.3"
+  "macos-homebrew"
+  "opensuse-15.6"
+  "opensuse-16.0"
+  "opensuse-tumbleweed"
+]

--- a/qcow-types.opam
+++ b/qcow-types.opam
@@ -25,6 +25,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/qcow.opam
+++ b/qcow.opam
@@ -38,6 +38,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
In OCaml 4.12 and lower, typechecking of a test module fails. This makes the checks in opam-repository to fail for these versions.

Since I can't get that version to compile on my machine, and xapi seems to be the only active user, drop support for OCaml 4.12 entirely.

Also regenerates metadatafrom dune-project, enforces a minimum alcotest version, and ignores expected values