### PR TITLE
qcow_stream: Fix progress reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.15.0 (2026-07-21)
+- qcow_stream: Fix reporting of progress (last-genius #139)
+
 ## 0.14.0 (2026-04-10)
 - qcow_stream: Fix handling of images >4tb (last-genius #136)
 

--- a/lib/qcow_mapping.ml
+++ b/lib/qcow_mapping.ml
@@ -10,6 +10,8 @@ external set : t -> int64 -> int64 -> unit = "stub_qcow_mapping_set"
 
 external length : t -> int64 = "stub_qcow_mapping_length"
 
+external filled : t -> int64 = "stub_qcow_mapping_filled"
+
 external get_sparse_interval_stub :
   t -> int64 -> int64 -> (int64 * int64 * int64) option
   = "stub_qcow_mapping_get_sparse_interval"

--- a/lib/qcow_mapping.mli
+++ b/lib/qcow_mapping.mli
@@ -10,6 +10,8 @@ val set : t -> int64 -> int64 -> unit
 
 val length : t -> int64
 
+val filled : t -> int64
+
 (** [to_interval_seq t cluster_bits] returns a sequence of allocated virtual
     data cluster intervals, intended to be used with sparse disks.
 

--- a/lib/qcow_mapping_stubs.c
+++ b/lib/qcow_mapping_stubs.c
@@ -11,6 +11,7 @@
 
 typedef struct array {
     uint64_t length;
+    uint64_t filled;
     int64_t* a;
 } array;
 
@@ -50,6 +51,7 @@ stub_qcow_mapping_create (value length_val)
     array *arr = malloc(sizeof *arr);
 
     arr->length = Int64_val(length_val);
+    arr->filled = 0;
     result = caml_alloc_custom(&qcow_mapping_ops, sizeof(array *), 0, 1);
 
     caml_release_runtime_system();
@@ -122,6 +124,7 @@ stub_qcow_mapping_set (value t_val, value index_val, value new_val)
     uint64_t index = Int64_val(index_val);
     int64_t new = Int64_val(new_val);
     arr->a[index] = new;
+    arr->filled++;
 
     CAMLreturn(Val_unit);
 }
@@ -138,6 +141,17 @@ stub_qcow_mapping_length (value t_val)
     CAMLreturn(result);
 }
 
+CAMLprim value
+stub_qcow_mapping_filled (value t_val)
+{
+    CAMLparam1(t_val);
+    CAMLlocal1(result);
+
+    array *arr = qcow_mapping_arr_of_val(t_val);
+    result = caml_copy_int64(arr->filled);
+
+    CAMLreturn(result);
+}
 
 CAMLprim value
 stub_qcow_mapping_get_sparse_interval (value t_val, value index_val, value cluster_bits_val)

--- a/lib/qcow_stream.ml
+++ b/lib/qcow_stream.ml
@@ -451,6 +451,8 @@ let copy_data ~progress_cb last_read_cluster cluster_bits input_fd output_fd
   in
 
   let max_cluster = Int64.to_int (Qcow_mapping.length data_cluster_map) in
+  let filled_clusters = Int64.to_int (Qcow_mapping.filled data_cluster_map) in
+  let processed_clusters = ref 0 in
   let cur_percent = ref 0 in
 
   for%lwt cluster = 0 to max_cluster - 1 do
@@ -463,12 +465,13 @@ let copy_data ~progress_cb last_read_cluster cluster_bits input_fd output_fd
       Log.debug (fun f ->
           f "copy cluster: %d, file_offset : %Lu\n" cluster file_offset
       ) ;
-      let now_percent = cluster / (max_cluster * 100) in
+      let now_percent = (!processed_clusters * 100) / filled_clusters in
       if now_percent > !cur_percent then (
         cur_percent := now_percent ;
         progress_cb now_percent
       ) ;
       let* buf = read_cluster_bytes (Cluster.of_int cluster) in
+      processed_clusters := !processed_clusters + 1;
       match buf with
       | Ok buf ->
           complete_pwrite_bytes output_fd buf (Int64.to_int file_offset)


### PR DESCRIPTION
To get an integer percentage value of the number of clusters processed so far from the total number of allocated clusters, add a new field "filled" to `Qcow_mapping.t` (since the `length` of `Qcow_mapping.t` is usually much bigger than the real number of clusters, we need an additional field to track this).

Fix the calculation of `now_percent`.